### PR TITLE
feat: OpenAI-compatible streaming, /v1/models, model discovery, opencode compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,10 @@ skills-lock.json
 # Data directory (SQLite DB)
 data/
 *.db
+
+# Test scripts
+test_api.py
+test_stream_api.py
+test_stream.json
+test_nonstream.json
+test_stream_req.json

--- a/cache/redis_client.py
+++ b/cache/redis_client.py
@@ -21,6 +21,21 @@ class RedisCache:
 # Increased threshold to 0.9 to avoid false positive matches between distinct semantic statements
         self.similarity_threshold = 0.9
 
+    def _extract_text(self, messages) -> str:
+        parts = []
+        for m in messages:
+            if not m.content:
+                continue
+            if isinstance(m.content, str):
+                parts.append(m.content)
+            elif isinstance(m.content, list):
+                for part in m.content:
+                    if isinstance(part, dict) and part.get("type") == "text":
+                        parts.append(part.get("text", ""))
+                    elif isinstance(part, str):
+                        parts.append(part)
+        return " ".join(parts)
+
     def _get_embedding(self, text: str) -> np.ndarray:
         """Helper to generate an embedding for the given text using Gemini."""
         try:
@@ -48,7 +63,7 @@ class RedisCache:
     async def get_cached_response(self, request: ChatCompletionRequest) -> Tuple[Optional[ChatCompletionResponse], float]:
         """Fetch a cached response if available using semantic caching, and return the highest similarity."""
         # 1. Combine messages into a single text for embedding
-        messages_text = " ".join([m.content for m in request.messages if m.content])
+        messages_text = self._extract_text(request.messages)
         if not messages_text:
             return None, -1.0
             
@@ -102,7 +117,7 @@ class RedisCache:
     async def set_cached_response(self, request: ChatCompletionRequest, response: ChatCompletionResponse):
         """Store a response in the cache along with its embedding."""
         
-        messages_text = " ".join([m.content for m in request.messages if m.content])
+        messages_text = self._extract_text(request.messages)
         request_embedding = self._get_embedding(messages_text)
         
         if request_embedding is None:

--- a/cache/redis_client.py
+++ b/cache/redis_client.py
@@ -6,20 +6,51 @@ from core.config import settings
 from google import genai
 import numpy as np
 
-# Since we use async, typical redis library needs to be aware or we use aioredis (now part of redis-py 4.2+)
 import redis.asyncio as redis
+
+SIMILARITY_PRESETS = {
+    "strict": 0.95,
+    "balanced": 0.9,
+    "aggressive": 0.6,
+}
+
+_cache_config = {
+    "ttl": 3600,
+    "similarity_threshold": 0.9,
+}
+
+
+def get_cache_config() -> Dict[str, Any]:
+    return dict(_cache_config)
+
+
+def set_cache_config(ttl: Optional[int] = None, similarity_threshold: Optional[float] = None):
+    if ttl is not None:
+        _cache_config["ttl"] = ttl
+    if similarity_threshold is not None:
+        _cache_config["similarity_threshold"] = similarity_threshold
+
+
+def resolve_similarity_threshold(request_similarity: Optional[str]) -> float:
+    if request_similarity is None:
+        return _cache_config["similarity_threshold"]
+    if request_similarity in SIMILARITY_PRESETS:
+        return SIMILARITY_PRESETS[request_similarity]
+    try:
+        val = float(request_similarity)
+        if 0.0 <= val <= 1.0:
+            return val
+    except (ValueError, TypeError):
+        pass
+    return _cache_config["similarity_threshold"]
+
 
 class RedisCache:
     def __init__(self):
         self.redis_client = redis.from_url(settings.REDIS_URL, decode_responses=True)
-        # Default TTL of 1 hour for MVP
-        self.ttl = 3600
-        
-        # Initialize Google GenAI client for embeddings
+
         self.genai_client = genai.Client(api_key=settings.GOOGLE_API_KEY)
         self.embedding_model = "gemini-embedding-001"
-# Increased threshold to 0.9 to avoid false positive matches between distinct semantic statements
-        self.similarity_threshold = 0.9
 
     def _extract_text(self, messages) -> str:
         parts = []
@@ -36,106 +67,123 @@ class RedisCache:
                         parts.append(part)
         return " ".join(parts)
 
-    def _get_embedding(self, text: str) -> np.ndarray:
-        """Helper to generate an embedding for the given text using Gemini."""
+    def _get_embedding(self, text: str) -> Optional[np.ndarray]:
         try:
             result = self.genai_client.models.embed_content(
                 model=self.embedding_model,
                 contents=text
             )
-            # embeddings[0].values contains the list of floats
             return np.array(result.embeddings[0].values)
         except Exception as e:
             print(f"Error generating embedding: {e}")
             return None
 
     def _generate_key(self, request: ChatCompletionRequest) -> str:
-        """
-        Generate a unique key based on the exact match of the prompt sequence and model.
-        In MVP this is a simple exact match hash.
-        """
-        # Serialize messages to a stable string
         messages_str = json.dumps([m.model_dump() for m in request.messages], sort_keys=True)
-        # Include model and temperature to ensure distinct caches for different generation params
         combined = f"{request.model}_{request.temperature}_{messages_str}"
         return f"nexus:cache:{hashlib.sha256(combined.encode()).hexdigest()}"
 
-    async def get_cached_response(self, request: ChatCompletionRequest) -> Tuple[Optional[ChatCompletionResponse], float]:
-        """Fetch a cached response if available using semantic caching, and return the highest similarity."""
-        # 1. Combine messages into a single text for embedding
+    async def get_cached_response(
+        self,
+        request: ChatCompletionRequest,
+        similarity_threshold: Optional[float] = None,
+        aggressive_fallback: bool = False,
+    ) -> Tuple[Optional[ChatCompletionResponse], float]:
+        """Fetch a cached response if available using semantic caching.
+
+        Args:
+            request: The chat completion request.
+            similarity_threshold: Override threshold for this request.
+            aggressive_fallback: If True, return the best match regardless of
+                threshold — used when the upstream model call fails.
+        """
         messages_text = self._extract_text(request.messages)
         if not messages_text:
             return None, -1.0
-            
+
         request_embedding = self._get_embedding(messages_text)
         if request_embedding is None:
             return None, -1.0
 
-        # 2. Fetch all keys in the cache
-        # For a full production system, vector dbs (Redis Stack) or dedicated indices should be used.
-        # This is an MVP implementation manually iterating over keys.
         keys = await self.redis_client.keys("nexus:cache:*")
-        
+
         best_match = None
         highest_similarity = -1.0
-        
+
         for key in keys:
             cached_data = await self.redis_client.get(key)
             if not cached_data:
                 continue
-                
+
             try:
                 data_dict = json.loads(cached_data)
-                
-                # Extract embedding and calculation similarity
+
                 if "embedding" in data_dict:
                     cached_embedding = np.array(data_dict["embedding"])
-                    
-                    # Cosine similarity formula: dot(a, b) / (norm(a) * norm(b))
+
                     similarity = np.dot(request_embedding, cached_embedding) / (np.linalg.norm(request_embedding) * np.linalg.norm(cached_embedding))
-                    
+
                     if similarity > highest_similarity:
                         highest_similarity = float(similarity)
                         best_match = data_dict
             except Exception as e:
                 print(f"Error reading cache for key {key}: {e}")
                 continue
-                
-        # 3. If the highest similarity exceeds the threshold, return the cached result
-        if best_match and highest_similarity >= self.similarity_threshold:
-            print(f"Cache hit! Semantic similarity: {highest_similarity:.4f}")
-            # The cached item is a specialized format containing "response", "embedding", and "model"
-            try:
-                # We expect the payload stored inside the "response" key to map to ChatCompletionResponse
-                if "response" in best_match:
-                     return ChatCompletionResponse(**best_match["response"]), highest_similarity
-            except Exception as e:
-                 print(f"Failed to parse cached response: {e}")
-                 
+
+        threshold = similarity_threshold if similarity_threshold is not None else _cache_config["similarity_threshold"]
+
+        if best_match:
+            if aggressive_fallback and highest_similarity > 0.0:
+                print(f"Aggressive fallback! Best similarity: {highest_similarity:.4f}")
+                try:
+                    if "response" in best_match:
+                        return ChatCompletionResponse(**best_match["response"]), highest_similarity
+                except Exception as e:
+                    print(f"Failed to parse cached response (fallback): {e}")
+
+            if highest_similarity >= threshold:
+                print(f"Cache hit! Semantic similarity: {highest_similarity:.4f}")
+                try:
+                    if "response" in best_match:
+                        return ChatCompletionResponse(**best_match["response"]), highest_similarity
+                except Exception as e:
+                    print(f"Failed to parse cached response: {e}")
+
         return None, highest_similarity
 
     async def set_cached_response(self, request: ChatCompletionRequest, response: ChatCompletionResponse):
-        """Store a response in the cache along with its embedding."""
-        
         messages_text = self._extract_text(request.messages)
         request_embedding = self._get_embedding(messages_text)
-        
+
         if request_embedding is None:
-             print("Failed to generate embedding; bypassing cache storage.")
-             return
-             
+            print("Failed to generate embedding; bypassing cache storage.")
+            return
+
         key = self._generate_key(request)
-        
-        # Package embedding together with response mapping for semantic retrieval
+
         cache_payload = {
-            "embedding": request_embedding.tolist(), # list for JSON serialization
+            "embedding": request_embedding.tolist(),
             "response": response.model_dump(exclude_unset=True),
             "original_model": request.model
         }
-        
-        # Exclude unset to avoid bloated JSON
+
         await self.redis_client.setex(
             key,
-            self.ttl,
+            _cache_config["ttl"],
             json.dumps(cache_payload)
         )
+
+    async def get_cache_stats(self) -> Dict[str, Any]:
+        keys = await self.redis_client.keys("nexus:cache:*")
+        return {
+            "entry_count": len(keys),
+            "ttl": _cache_config["ttl"],
+            "similarity_threshold": _cache_config["similarity_threshold"],
+            "similarity_presets": SIMILARITY_PRESETS,
+        }
+
+    async def flush_cache(self) -> int:
+        keys = await self.redis_client.keys("nexus:cache:*")
+        if keys:
+            await self.redis_client.delete(*keys)
+        return len(keys)

--- a/core/database.py
+++ b/core/database.py
@@ -23,6 +23,8 @@ CREATE TABLE IF NOT EXISTS api_keys (
     provider TEXT NOT NULL,
     api_key_encrypted TEXT NOT NULL,
     label TEXT NOT NULL DEFAULT '',
+    base_url TEXT,
+    model_cards TEXT,
     is_enabled INTEGER NOT NULL DEFAULT 1,
     rate_limit_remaining_tokens INTEGER,
     rate_limit_remaining_requests INTEGER,
@@ -96,6 +98,16 @@ async def init_db():
         await db.execute("ALTER TABLE api_keys ADD COLUMN rate_limit_resets_at TEXT")
         await db.commit()
         logger.info("Migrated: added rate_limit_resets_at column")
+
+    if "base_url" not in cols:
+        await db.execute("ALTER TABLE api_keys ADD COLUMN base_url TEXT")
+        await db.commit()
+        logger.info("Migrated: added base_url column")
+
+    if "model_cards" not in cols:
+        await db.execute("ALTER TABLE api_keys ADD COLUMN model_cards TEXT")
+        await db.commit()
+        logger.info("Migrated: added model_cards column")
 
     logger.info("Database schema initialized successfully.")
 

--- a/core/key_manager.py
+++ b/core/key_manager.py
@@ -5,8 +5,10 @@ rate-limit tracking, and key selection for provider routing.
 
 import logging
 import re
+import json
 from datetime import datetime, timezone, timedelta
-from typing import Optional, Tuple, List, Dict, Any
+from typing import Optional, Tuple, List, Dict, Any, Set
+from urllib.parse import urlparse
 
 from cryptography.fernet import Fernet
 
@@ -114,12 +116,31 @@ class KeyManager:
         provider: str,
         api_key: str,
         label: str = "",
+        base_url: Optional[str] = None,
+        model_cards: Optional[List[str]] = None,
     ) -> int:
+        provider_normalized = provider.lower()
+        normalized_base_url = self._normalize_base_url(base_url)
+        normalized_model_cards = self._normalize_model_cards(model_cards)
+
+        if provider_normalized == "openai-compatible":
+            if not normalized_base_url:
+                raise ValueError("base_url is required for provider 'openai-compatible'")
+
         encrypted = encrypt_key(api_key)
         db = await get_db()
         cursor = await db.execute(
-            "INSERT INTO api_keys (provider, api_key_encrypted, label) VALUES (?, ?, ?)",
-            (provider.lower(), encrypted, label),
+            """
+            INSERT INTO api_keys (provider, api_key_encrypted, label, base_url, model_cards)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                provider_normalized,
+                encrypted,
+                label,
+                normalized_base_url,
+                json.dumps(normalized_model_cards) if normalized_model_cards else None,
+            ),
         )
         await db.commit()
         key_id = cursor.lastrowid
@@ -144,6 +165,15 @@ class KeyManager:
                 d["api_key_masked"] = mask_key(plain)
             except Exception:
                 d["api_key_masked"] = "****"
+            raw_model_cards = d.get("model_cards")
+            if raw_model_cards:
+                try:
+                    parsed_cards = json.loads(raw_model_cards)
+                    d["model_cards"] = parsed_cards if isinstance(parsed_cards, list) else []
+                except Exception:
+                    d["model_cards"] = []
+            else:
+                d["model_cards"] = []
             del d["api_key_encrypted"]
             results.append(d)
         return results
@@ -153,6 +183,14 @@ class KeyManager:
         cursor = await db.execute("DELETE FROM api_keys WHERE id = ?", (key_id,))
         await db.commit()
         return cursor.rowcount > 0
+
+    async def decrypt_key_by_id(self, key_id: int) -> str:
+        db = await get_db()
+        cursor = await db.execute("SELECT api_key_encrypted FROM api_keys WHERE id = ?", (key_id,))
+        row = await cursor.fetchone()
+        if not row:
+            raise ValueError(f"Key id={key_id} not found")
+        return decrypt_key(row["api_key_encrypted"])
 
     async def toggle_key(self, key_id: int, enabled: bool) -> bool:
         db = await get_db()
@@ -216,6 +254,73 @@ class KeyManager:
 
         raise RuntimeError(f"No enabled API keys available for provider '{provider}'")
 
+    async def get_available_key_for_model(
+        self,
+        model: str,
+        exclude_key_ids: Optional[Set[int]] = None,
+        supported_providers: Optional[Set[str]] = None,
+    ) -> Tuple[str, int, str, Optional[str], List[str]]:
+        """
+        Pick the best key across providers for a requested model.
+        Priority:
+        1) Any key with matching model card and NULL remaining tokens (never used)
+        2) Any key with matching model card and remaining tokens > threshold (highest remaining first)
+        3) Any key with matching model card and earliest reset time
+        """
+        db = await get_db()
+        cursor = await db.execute(
+            """
+            SELECT id, provider, api_key_encrypted, base_url, model_cards, rate_limit_remaining_tokens
+            FROM api_keys
+            WHERE is_enabled = 1
+            ORDER BY
+              CASE WHEN rate_limit_remaining_tokens IS NULL THEN 0 ELSE 1 END,
+              rate_limit_remaining_tokens DESC,
+              rate_limit_resets_at ASC
+            """
+        )
+        rows = await cursor.fetchall()
+        excluded = exclude_key_ids or set()
+        supported = {p.lower() for p in supported_providers} if supported_providers else None
+
+        normalized_model = (model or "").strip()
+        if not normalized_model:
+            raise RuntimeError("Model name is required")
+
+        explicit_matches = []
+        wildcard_matches = []
+        for row in rows:
+            if row["id"] in excluded:
+                continue
+            if supported and row["provider"] not in supported:
+                continue
+            cards = self._parse_model_cards(row["model_cards"])
+            if cards:
+                if normalized_model in cards:
+                    explicit_matches.append(row)
+            else:
+                wildcard_matches.append(row)
+
+        matching_rows = explicit_matches if explicit_matches else wildcard_matches
+
+        if not matching_rows:
+            raise RuntimeError(f"No enabled API keys support model '{normalized_model}'")
+
+        for row in matching_rows:
+            remaining = row["rate_limit_remaining_tokens"]
+            if remaining is None or remaining > self.MIN_TOKENS_THRESHOLD:
+                plain = decrypt_key(row["api_key_encrypted"])
+                return plain, row["id"], row["provider"], row["base_url"], self._parse_model_cards(row["model_cards"])
+
+        fallback = matching_rows[0]
+        plain = decrypt_key(fallback["api_key_encrypted"])
+        logger.warning(
+            "All matching keys below threshold for model %s — using key id=%s",
+            normalized_model,
+            fallback["id"],
+        )
+        return plain, fallback["id"], fallback["provider"], fallback["base_url"], self._parse_model_cards(fallback["model_cards"])
+
     # ---- rate-limit updates ----
 
     async def update_rate_limits(self, key_id: int, headers: dict):
@@ -275,6 +380,51 @@ class KeyManager:
         if row["cnt"] == 0:
             await self.add_key("groq", settings.GROQ_API_KEY, "env-default")
             logger.info("Seeded GROQ_API_KEY from environment into database.")
+
+    @staticmethod
+    def _normalize_base_url(base_url: Optional[str]) -> Optional[str]:
+        if base_url is None:
+            return None
+        candidate = base_url.strip()
+        if not candidate:
+            return None
+        parsed = urlparse(candidate)
+        if parsed.scheme not in ("http", "https") or not parsed.netloc:
+            raise ValueError("base_url must be a valid http/https URL")
+        return candidate.rstrip("/")
+
+    @staticmethod
+    def _normalize_model_cards(model_cards: Optional[List[str]]) -> List[str]:
+        if not model_cards:
+            return []
+        cleaned: List[str] = []
+        seen = set()
+        for item in model_cards:
+            if not isinstance(item, str):
+                continue
+            model = item.strip()
+            if not model:
+                continue
+            if model in seen:
+                continue
+            seen.add(model)
+            cleaned.append(model)
+        return cleaned
+
+    @staticmethod
+    def _parse_model_cards(raw_model_cards: Any) -> List[str]:
+        if not raw_model_cards:
+            return []
+        if isinstance(raw_model_cards, list):
+            return [x for x in raw_model_cards if isinstance(x, str) and x.strip()]
+        if isinstance(raw_model_cards, str):
+            try:
+                parsed = json.loads(raw_model_cards)
+                if isinstance(parsed, list):
+                    return [x for x in parsed if isinstance(x, str) and x.strip()]
+            except Exception:
+                return []
+        return []
 
 
     # ---- background sweeper ----

--- a/core/key_manager.py
+++ b/core/key_manager.py
@@ -15,6 +15,20 @@ from cryptography.fernet import Fernet
 from core.config import settings
 from core.database import get_db
 
+
+class _UnsetType:
+    _instance = None
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+    def __repr__(self):
+        return "UNSET"
+    def __bool__(self):
+        return False
+
+UNSET = _UnsetType()
+
 logger = logging.getLogger("switchboard.key_manager")
 
 
@@ -200,6 +214,89 @@ class KeyManager:
         )
         await db.commit()
         return cursor.rowcount > 0
+
+    async def update_key(
+        self,
+        key_id: int,
+        provider: Optional[str] = None,
+        api_key: Optional[str] = None,
+        label: Optional[str] = None,
+        base_url: Any = UNSET,
+        model_cards: Any = UNSET,
+        is_enabled: Optional[bool] = None,
+    ) -> bool:
+        db = await get_db()
+        cursor = await db.execute(
+            "SELECT id, provider, base_url FROM api_keys WHERE id = ?", (key_id,)
+        )
+        row = await cursor.fetchone()
+        if not row:
+            return False
+
+        effective_provider = (provider or row["provider"]).lower()
+        existing_base_url = row["base_url"]
+
+        sets = []
+        vals = []
+
+        if provider is not None:
+            sets.append("provider = ?")
+            vals.append(provider.lower())
+
+        if api_key is not None:
+            encrypted = encrypt_key(api_key)
+            sets.append("api_key_encrypted = ?")
+            vals.append(encrypted)
+
+        if label is not None:
+            sets.append("label = ?")
+            vals.append(label)
+
+        if base_url is not UNSET:
+            normalized = self._normalize_base_url(base_url) if isinstance(base_url, str) else None
+            if effective_provider == "openai-compatible" and not normalized and not existing_base_url:
+                raise ValueError("base_url is required for provider 'openai-compatible'")
+            sets.append("base_url = ?")
+            vals.append(normalized)
+
+        if model_cards is not UNSET:
+            cleaned = self._normalize_model_cards(model_cards)
+            sets.append("model_cards = ?")
+            vals.append(json.dumps(cleaned) if cleaned else None)
+
+        if is_enabled is not None:
+            sets.append("is_enabled = ?")
+            vals.append(1 if is_enabled else 0)
+
+        if not sets:
+            return True
+
+        vals.append(key_id)
+        sql = f"UPDATE api_keys SET {', '.join(sets)} WHERE id = ?"
+        await db.execute(sql, vals)
+        await db.commit()
+        logger.info(f"Updated key id={key_id} fields={sets}")
+        return True
+
+    async def get_key_rate_limits(self, key_id: int) -> Optional[Dict[str, Any]]:
+        db = await get_db()
+        cursor = await db.execute(
+            """SELECT rate_limit_remaining_tokens, rate_limit_remaining_requests,
+                      rate_limit_reset_tokens, rate_limit_reset_requests,
+                      rate_limit_resets_at
+               FROM api_keys WHERE id = ?""",
+            (key_id,),
+        )
+        row = await cursor.fetchone()
+        if not row:
+            return None
+        return {
+            "remaining_tokens": row["rate_limit_remaining_tokens"],
+            "remaining_requests": row["rate_limit_remaining_requests"],
+            "reset_tokens": row["rate_limit_reset_tokens"],
+            "reset_requests": row["rate_limit_reset_requests"],
+            "resets_at": row["rate_limit_resets_at"],
+        }
 
     # ---- key selection ----
 

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -24,6 +24,8 @@ class ChatCompletionRequest(BaseModel):
     seed: Optional[int] = None
     tools: Optional[List[Dict[str, Any]]] = None
     tool_choice: Optional[Union[str, Dict[str, Any]]] = None
+    similarity: Optional[str] = None
+    model_use: Optional[bool] = True
 
 class Usage(BaseModel):
     prompt_tokens: int = 0

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -1,15 +1,29 @@
 from pydantic import BaseModel, Field
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Union
 
 class ChatMessage(BaseModel):
+    model_config = {"extra": "allow"}
     role: str
-    content: str
+    content: Optional[str] = None
 
 class ChatCompletionRequest(BaseModel):
+    model_config = {"extra": "allow"}
     model: str
     messages: List[ChatMessage]
     temperature: Optional[float] = 0.7
+    top_p: Optional[float] = None
+    n: Optional[int] = None
     stream: Optional[bool] = False
+    stop: Optional[Union[str, List[str]]] = None
+    max_tokens: Optional[int] = None
+    presence_penalty: Optional[float] = None
+    frequency_penalty: Optional[float] = None
+    logit_bias: Optional[Dict[str, float]] = None
+    user: Optional[str] = None
+    response_format: Optional[Dict[str, Any]] = None
+    seed: Optional[int] = None
+    tools: Optional[List[Dict[str, Any]]] = None
+    tool_choice: Optional[Union[str, Dict[str, Any]]] = None
 
 class Usage(BaseModel):
     prompt_tokens: int = 0

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Dict, Any, Union
 class ChatMessage(BaseModel):
     model_config = {"extra": "allow"}
     role: str
-    content: Optional[str] = None
+    content: Optional[Union[str, List[Any]]] = None
 
 class ChatCompletionRequest(BaseModel):
     model_config = {"extra": "allow"}

--- a/gateway/admin.py
+++ b/gateway/admin.py
@@ -5,13 +5,14 @@ Mounted at /admin in the gateway.
 
 import json
 import logging
-from typing import Optional, List
+from typing import Any, Optional, List
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
-from core.key_manager import key_manager
+from core.key_manager import key_manager, UNSET
 from core.database import get_db, get_usage_stats
+from cache.redis_client import get_cache_config, set_cache_config
 from providers.groq_provider import GroqProvider
 from providers.openai_compatible_provider import OpenAICompatibleProvider
 
@@ -32,6 +33,21 @@ class AddKeyRequest(BaseModel):
 
 class ToggleKeyRequest(BaseModel):
     is_enabled: bool
+
+class UpdateKeyRequest(BaseModel):
+    provider: Optional[str] = None
+    api_key: Optional[str] = None
+    label: Optional[str] = None
+    base_url: Any = UNSET
+    model_cards: Any = UNSET
+    is_enabled: Optional[bool] = None
+
+    model_config = {"arbitrary_types_allowed": True}
+
+
+class CacheConfigRequest(BaseModel):
+    ttl: Optional[int] = None
+    similarity_threshold: Optional[float] = None
 
 
 # ---- endpoints ----
@@ -75,6 +91,26 @@ async def toggle_key(key_id: int, body: ToggleKeyRequest):
     if not updated:
         raise HTTPException(status_code=404, detail="Key not found")
     return {"message": f"Key {'enabled' if body.is_enabled else 'disabled'}"}
+
+
+@admin_router.put("/keys/{key_id}")
+async def update_key(key_id: int, body: UpdateKeyRequest):
+    """Update editable fields of an API key."""
+    try:
+        updated = await key_manager.update_key(
+            key_id,
+            provider=body.provider,
+            api_key=body.api_key,
+            label=body.label,
+            base_url=body.base_url,
+            model_cards=body.model_cards,
+            is_enabled=body.is_enabled,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    if not updated:
+        raise HTTPException(status_code=404, detail="Key not found")
+    return {"message": "Key updated"}
 
 
 @admin_router.get("/providers")
@@ -195,3 +231,33 @@ async def discover_models(key_id: int):
     await db.commit()
 
     return {"key_id": key_id, "discovered_models": model_ids, "count": len(model_ids)}
+
+
+@admin_router.get("/cache/config")
+async def get_cache_config_endpoint():
+    """Get current cache configuration (TTL, similarity threshold, presets)."""
+    from cache.redis_client import RedisCache
+    config = get_cache_config()
+    cache = RedisCache()
+    stats = await cache.get_cache_stats()
+    return {**config, "entry_count": stats["entry_count"], "similarity_presets": stats["similarity_presets"]}
+
+
+@admin_router.put("/cache/config")
+async def update_cache_config(body: CacheConfigRequest):
+    """Update cache configuration (TTL and/or similarity threshold)."""
+    if body.ttl is not None and body.ttl < 1:
+        raise HTTPException(status_code=400, detail="TTL must be at least 1 second")
+    if body.similarity_threshold is not None and not (0.0 <= body.similarity_threshold <= 1.0):
+        raise HTTPException(status_code=400, detail="Similarity threshold must be between 0.0 and 1.0")
+    set_cache_config(ttl=body.ttl, similarity_threshold=body.similarity_threshold)
+    return get_cache_config()
+
+
+@admin_router.post("/cache/flush")
+async def flush_cache():
+    """Delete all cached entries."""
+    from cache.redis_client import RedisCache
+    cache = RedisCache()
+    count = await cache.flush_cache()
+    return {"flushed": count}

--- a/gateway/admin.py
+++ b/gateway/admin.py
@@ -3,14 +3,17 @@ Admin API — CRUD for API keys and provider management.
 Mounted at /admin in the gateway.
 """
 
+import json
 import logging
-from typing import Optional
+from typing import Optional, List
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from core.key_manager import key_manager
-from core.database import get_usage_stats
+from core.database import get_db, get_usage_stats
+from providers.groq_provider import GroqProvider
+from providers.openai_compatible_provider import OpenAICompatibleProvider
 
 logger = logging.getLogger("switchboard.admin")
 
@@ -23,6 +26,8 @@ class AddKeyRequest(BaseModel):
     provider: str
     api_key: str
     label: str = ""
+    base_url: Optional[str] = None
+    model_cards: Optional[List[str]] = None
 
 
 class ToggleKeyRequest(BaseModel):
@@ -34,11 +39,16 @@ class ToggleKeyRequest(BaseModel):
 @admin_router.post("/keys")
 async def add_key(body: AddKeyRequest):
     """Add a new API key for a provider."""
-    key_id = await key_manager.add_key(
-        provider=body.provider,
-        api_key=body.api_key,
-        label=body.label,
-    )
+    try:
+        key_id = await key_manager.add_key(
+            provider=body.provider,
+            api_key=body.api_key,
+            label=body.label,
+            base_url=body.base_url,
+            model_cards=body.model_cards,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     return {"id": key_id, "message": "Key added successfully"}
 
 
@@ -144,3 +154,44 @@ async def get_stats():
             for k in all_keys
         ],
     }
+
+
+@admin_router.post("/discover-models/{key_id}")
+async def discover_models(key_id: int):
+    """Fetch available models from a provider's API and update that key's model_cards."""
+    keys = await key_manager.list_keys()
+    key = next((k for k in keys if k["id"] == key_id), None)
+    if not key:
+        raise HTTPException(status_code=404, detail="Key not found")
+
+    provider_name = key["provider"]
+    try:
+        api_key_plain = await key_manager.decrypt_key_by_id(key_id)
+    except Exception:
+        raise HTTPException(status_code=500, detail="Failed to decrypt API key")
+
+    if provider_name == "groq":
+        provider = GroqProvider(api_key=api_key_plain)
+    elif provider_name == "openai-compatible":
+        base_url = key.get("base_url")
+        if not base_url:
+            raise HTTPException(status_code=400, detail="Key has no base_url configured")
+        provider = OpenAICompatibleProvider(api_key=api_key_plain, base_url=base_url, provider_name=provider_name)
+    else:
+        raise HTTPException(status_code=400, detail=f"Model discovery not supported for provider '{provider_name}'")
+
+    models = await provider.list_models()
+    if not models:
+        raise HTTPException(status_code=502, detail="No models returned from provider API")
+
+    model_ids = [m.get("id", m.get("name", "")) for m in models if m.get("id") or m.get("name")]
+    model_ids = [m for m in model_ids if m]
+
+    db = await get_db()
+    await db.execute(
+        "UPDATE api_keys SET model_cards = ? WHERE id = ?",
+        (json.dumps(model_ids), key_id),
+    )
+    await db.commit()
+
+    return {"key_id": key_id, "discovered_models": model_ids, "count": len(model_ids)}

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -14,7 +14,7 @@ from core.database import init_db, cleanup_old_buckets
 from core.key_manager import key_manager
 from core.metrics import CACHE_HITS, CACHE_MISSES, ACTIVE_KEYS
 from routing.router import Router
-from cache.redis_client import RedisCache
+from cache.redis_client import RedisCache, resolve_similarity_threshold
 from gateway.admin import admin_router
 
 # Setup logging
@@ -147,23 +147,32 @@ async def chat_completions(request: ChatCompletionRequest, response: Response):
             },
         )
 
-    # Non-streaming path
-    highest_similarity = -1.0
-    try:
-        cached_response, highest_similarity = await cache.get_cached_response(request)
-        if cached_response:
-            logger.info("Cache hit!")
-            CACHE_HITS.inc()
-            response.headers["X-Cache"] = "HIT"
-            response.headers["X-Semantic-Similarity"] = f"{highest_similarity:.4f}"
-            return cached_response
-    except Exception as e:
-        logger.warning(f"Failed to fetch from cache: {str(e)}")
+    threshold = resolve_similarity_threshold(request.similarity)
+    use_model = request.model_use if request.model_use is not None else True
+    is_aggressive = request.similarity == "aggressive"
 
-    CACHE_MISSES.inc()
+    if not use_model:
+        try:
+            cached_response, sim = await cache.get_cached_response(
+                request, similarity_threshold=threshold,
+            )
+            if cached_response:
+                CACHE_HITS.inc()
+                response.headers["X-Cache"] = "HIT"
+                response.headers["X-Semantic-Similarity"] = f"{sim:.4f}"
+                response.headers["X-Model-Use"] = "false"
+                body = cached_response.model_dump()
+                body["similarity"] = round(sim, 4)
+                return body
+        except Exception as e:
+            logger.warning(f"Cache lookup failed: {str(e)}")
+        raise HTTPException(
+            status_code=503,
+            detail="model_use=false and no cached response available",
+        )
 
     try:
-        logger.info("Cache miss. Routing request to provider.")
+        logger.info("Routing request to provider.")
         provider_result = await router.route_request(request)
 
         try:
@@ -171,14 +180,35 @@ async def chat_completions(request: ChatCompletionRequest, response: Response):
         except Exception as e:
             logger.warning(f"Failed to write to cache: {str(e)}")
 
+        body = provider_result.response.model_dump()
+        rate_limits = await key_manager.get_key_rate_limits(provider_result.key_id)
+        if rate_limits:
+            body["rate_limits"] = rate_limits
         response.headers["X-Cache"] = "MISS"
         response.headers["X-Provider"] = provider_result.provider
         response.headers["X-Latency-Ms"] = f"{provider_result.latency_ms:.1f}"
-        if highest_similarity >= -1.0:
-            response.headers["X-Semantic-Similarity"] = f"{highest_similarity:.4f}"
-        return provider_result.response
+        return body
     except Exception as e:
         logger.error(f"Provider request failed: {str(e)}")
+
+        try:
+            fallback_resp, fallback_sim = await cache.get_cached_response(
+                request,
+                similarity_threshold=threshold,
+                aggressive_fallback=is_aggressive,
+            )
+            if fallback_resp:
+                logger.info(f"Cache fallback hit! similarity={fallback_sim:.4f}")
+                CACHE_HITS.inc()
+                response.headers["X-Cache"] = "FALLBACK"
+                response.headers["X-Semantic-Similarity"] = f"{fallback_sim:.4f}"
+                response.headers["X-Fallback-Reason"] = "provider-failure"
+                body = fallback_resp.model_dump()
+                body["similarity"] = round(fallback_sim, 4)
+                return body
+        except Exception as fallback_err:
+            logger.warning(f"Cache fallback also failed: {fallback_err}")
+
         raise HTTPException(status_code=502, detail=f"Bad Gateway: {str(e)}")
 
 

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -4,6 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 import asyncio
 import logging
+import httpx
 
 from prometheus_fastapi_instrumentator import Instrumentator
 
@@ -111,18 +112,40 @@ async def chat_completions(request: ChatCompletionRequest, response: Response):
     if request.stream:
         try:
             stream_gen = router.route_request_stream(request)
+            first_chunk = await stream_gen.__anext__()
+        except StopAsyncIteration:
             return StreamingResponse(
-                stream_gen,
+                iter([]),
                 media_type="text/event-stream",
-                headers={
-                    "X-Cache": "MISS",
-                    "Cache-Control": "no-cache",
-                    "Connection": "keep-alive",
-                },
             )
+        except HTTPException:
+            raise
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            detail = e.response.text[:500]
+            logger.error(f"Stream upstream error {status}: {detail}")
+            raise HTTPException(status_code=502, detail=f"Upstream error {status}: {detail}")
         except Exception as e:
             logger.error(f"Stream request failed: {str(e)}")
             raise HTTPException(status_code=502, detail=f"Bad Gateway: {str(e)}")
+
+        async def _stream_with_first():
+            yield first_chunk
+            try:
+                async for chunk in stream_gen:
+                    yield chunk
+            except Exception as e:
+                logger.error(f"Stream mid-flight error: {e}")
+
+        return StreamingResponse(
+            _stream_with_first(),
+            media_type="text/event-stream",
+            headers={
+                "X-Cache": "MISS",
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
+            },
+        )
 
     # Non-streaming path
     highest_similarity = -1.0

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI, HTTPException, Request, Response
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
 import asyncio
@@ -7,7 +7,7 @@ import logging
 
 from prometheus_fastapi_instrumentator import Instrumentator
 
-from core.schemas import ChatCompletionRequest, ChatCompletionResponse
+from core.schemas import ChatCompletionRequest
 from core.config import settings
 from core.database import init_db, cleanup_old_buckets
 from core.key_manager import key_manager
@@ -104,11 +104,27 @@ router = Router()
 cache = RedisCache()
 
 
-@app.post("/v1/chat/completions", response_model=ChatCompletionResponse)
+@app.post("/v1/chat/completions")
 async def chat_completions(request: ChatCompletionRequest, response: Response):
-    logger.info(f"Received request for model: {request.model}")
+    logger.info(f"Received request for model: {request.model} stream={request.stream}")
 
-    # 1. Check Cache
+    if request.stream:
+        try:
+            stream_gen = router.route_request_stream(request)
+            return StreamingResponse(
+                stream_gen,
+                media_type="text/event-stream",
+                headers={
+                    "X-Cache": "MISS",
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                },
+            )
+        except Exception as e:
+            logger.error(f"Stream request failed: {str(e)}")
+            raise HTTPException(status_code=502, detail=f"Bad Gateway: {str(e)}")
+
+    # Non-streaming path
     highest_similarity = -1.0
     try:
         cached_response, highest_similarity = await cache.get_cached_response(request)
@@ -123,12 +139,10 @@ async def chat_completions(request: ChatCompletionRequest, response: Response):
 
     CACHE_MISSES.inc()
 
-    # 2. Route Request to Provider (with automatic key rotation)
     try:
         logger.info("Cache miss. Routing request to provider.")
         provider_result = await router.route_request(request)
 
-        # 3. Store in Cache
         try:
             await cache.set_cached_response(request, provider_result.response)
         except Exception as e:
@@ -143,6 +157,26 @@ async def chat_completions(request: ChatCompletionRequest, response: Response):
     except Exception as e:
         logger.error(f"Provider request failed: {str(e)}")
         raise HTTPException(status_code=502, detail=f"Bad Gateway: {str(e)}")
+
+
+@app.get("/v1/models")
+async def list_models():
+    keys = await key_manager.list_keys()
+    seen = set()
+    models = []
+    for k in keys:
+        if not k.get("is_enabled"):
+            continue
+        for model_name in k.get("model_cards", []):
+            if model_name not in seen:
+                seen.add(model_name)
+                models.append({
+                    "id": model_name,
+                    "object": "model",
+                    "created": 0,
+                    "owned_by": k["provider"],
+                })
+    return {"object": "list", "data": models}
 
 
 @app.get("/health")

--- a/providers/base.py
+++ b/providers/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Any
+from typing import AsyncIterator, Dict, List, Any
 from core.schemas import ChatCompletionRequest, ProviderResult
 
 
@@ -9,6 +9,10 @@ class LLMProvider(ABC):
         """Send a request and return ProviderResult (response + metadata/headers)."""
         pass
 
+    async def generate_stream(self, request: ChatCompletionRequest) -> AsyncIterator[bytes]:
+        """Stream SSE chunks from the provider. Yields raw bytes."""
+        raise NotImplementedError("Streaming not supported by this provider")
+
     @abstractmethod
     async def health_check(self) -> bool:
         pass
@@ -17,3 +21,7 @@ class LLMProvider(ABC):
     async def get_cost_per_token(self) -> Dict[str, float]:
         """Returns input and output cost per token"""
         pass
+
+    async def list_models(self) -> List[Dict[str, Any]]:
+        """List available models from the provider's API. Returns list of model dicts with at least 'id' key."""
+        return []

--- a/providers/groq_provider.py
+++ b/providers/groq_provider.py
@@ -1,10 +1,26 @@
 import time
+import logging
 import httpx
-from typing import Dict, Any
+from typing import AsyncIterator, Dict, Any
 
 from providers.base import LLMProvider
 from core.schemas import ChatCompletionRequest, ChatCompletionResponse, ChatMessage, ChatChoice, Usage, ProviderResult
 from core.config import settings
+
+logger = logging.getLogger("switchboard.groq")
+
+_groq_client: httpx.AsyncClient | None = None
+
+
+async def get_groq_client() -> httpx.AsyncClient:
+    global _groq_client
+    if _groq_client is None or _groq_client.is_closed:
+        _groq_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=15.0, read=120.0, write=15.0, pool=15.0),
+            limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+        )
+    return _groq_client
+
 
 class GroqProvider(LLMProvider):
     def __init__(self, api_key: str | None = None):
@@ -16,72 +32,90 @@ class GroqProvider(LLMProvider):
         }
 
     async def generate(self, request: ChatCompletionRequest) -> ProviderResult:
-        async with httpx.AsyncClient() as client:
-            payload = request.model_dump(exclude_unset=True)
-            
-            # For MVP, disable streaming as it requires SSE handling
-            payload['stream'] = False
-            
-            start = time.time()
-            response = await client.post(
-                self.base_url,
-                headers=self.headers,
-                json=payload,
-                timeout=30.0
+        client = await get_groq_client()
+        payload = request.model_dump(exclude_unset=True)
+
+        start = time.time()
+        response = await client.post(
+            self.base_url,
+            headers=self.headers,
+            json=payload,
+        )
+        response.raise_for_status()
+        latency_ms = (time.time() - start) * 1000
+        data = response.json()
+
+        choices = []
+        for item in data.get("choices", []):
+            msg_data = item.get("message", {})
+            message = ChatMessage(role=msg_data.get("role", "assistant"), content=msg_data.get("content", ""))
+            choice = ChatChoice(
+                index=item.get("index", 0),
+                message=message,
+                finish_reason=item.get("finish_reason")
             )
+            choices.append(choice)
+
+        usage_data = data.get("usage", {})
+        usage = Usage(
+            prompt_tokens=usage_data.get("prompt_tokens", 0),
+            completion_tokens=usage_data.get("completion_tokens", 0),
+            total_tokens=usage_data.get("total_tokens", 0)
+        )
+
+        chat_response = ChatCompletionResponse(
+            id=data.get("id", f"chatcmpl-{int(time.time())}"),
+            created=data.get("created", int(time.time())),
+            model=data.get("model", request.model),
+            choices=choices,
+            usage=usage
+        )
+
+        rl_headers = {
+            k: v for k, v in response.headers.items()
+            if k.lower().startswith("x-ratelimit")
+        }
+
+        return ProviderResult(
+            response=chat_response,
+            provider="groq",
+            latency_ms=latency_ms,
+            rate_limit_headers=rl_headers,
+        )
+
+    async def generate_stream(self, request: ChatCompletionRequest) -> AsyncIterator[bytes]:
+        client = await get_groq_client()
+        payload = request.model_dump(exclude_unset=True)
+        payload["stream"] = True
+
+        async with client.stream(
+            "POST",
+            self.base_url,
+            headers=self.headers,
+            json=payload,
+        ) as response:
             response.raise_for_status()
-            latency_ms = (time.time() - start) * 1000
+            async for chunk in response.aiter_bytes():
+                yield chunk
+
+    async def list_models(self) -> list[dict]:
+        try:
+            url = "https://api.groq.com/openai/v1/models"
+            client = await get_groq_client()
+            response = await client.get(url, headers=self.headers)
+            response.raise_for_status()
             data = response.json()
-            
-            # Map Groq response to unified schema
-            choices = []
-            for item in data.get("choices", []):
-                msg_data = item.get("message", {})
-                message = ChatMessage(role=msg_data.get("role", "assistant"), content=msg_data.get("content", ""))
-                choice = ChatChoice(
-                    index=item.get("index", 0),
-                    message=message,
-                    finish_reason=item.get("finish_reason")
-                )
-                choices.append(choice)
-                
-            usage_data = data.get("usage", {})
-            usage = Usage(
-                prompt_tokens=usage_data.get("prompt_tokens", 0),
-                completion_tokens=usage_data.get("completion_tokens", 0),
-                total_tokens=usage_data.get("total_tokens", 0)
-            )
-            
-            chat_response = ChatCompletionResponse(
-                id=data.get("id", f"chatcmpl-{int(time.time())}"),
-                created=data.get("created", int(time.time())),
-                model=data.get("model", request.model),
-                choices=choices,
-                usage=usage
-            )
-
-            # Extract rate-limit headers for key rotation tracking
-            rl_headers = {
-                k: v for k, v in response.headers.items()
-                if k.lower().startswith("x-ratelimit")
-            }
-
-            return ProviderResult(
-                response=chat_response,
-                provider="groq",
-                latency_ms=latency_ms,
-                rate_limit_headers=rl_headers,
-            )
+            return data.get("data", [])
+        except Exception as e:
+            logger.warning(f"Failed to list models from Groq: {e}")
+            return []
 
     async def health_check(self) -> bool:
-        # Simple health check, maybe hitting a very lightweight endpoint or just checking API key config
         if not self.api_key:
             return False
-        # For simplicity in MVP, assume healthy if API key exists
         return True
 
     async def get_cost_per_token(self) -> Dict[str, float]:
-        # Very rough estimates for Llama 3 on Groq
         return {
             "input": 0.0000005,
             "output": 0.0000015

--- a/providers/groq_provider.py
+++ b/providers/groq_provider.py
@@ -94,7 +94,13 @@ class GroqProvider(LLMProvider):
             headers=self.headers,
             json=payload,
         ) as response:
-            response.raise_for_status()
+            if response.status_code >= 400:
+                body = await response.aread()
+                raise httpx.HTTPStatusError(
+                    f"Client error '{response.status_code} {response.reason_phrase}' for url '{response.url}'",
+                    request=response.request,
+                    response=response,
+                )
             async for chunk in response.aiter_bytes():
                 yield chunk
 

--- a/providers/openai_compatible_provider.py
+++ b/providers/openai_compatible_provider.py
@@ -123,7 +123,13 @@ class OpenAICompatibleProvider(LLMProvider):
             headers=self.headers,
             json=payload,
         ) as response:
-            response.raise_for_status()
+            if response.status_code >= 400:
+                body = await response.aread()
+                raise httpx.HTTPStatusError(
+                    f"Client error '{response.status_code} {response.reason_phrase}' for url '{response.url}'",
+                    request=response.request,
+                    response=response,
+                )
             async for chunk in response.aiter_bytes():
                 yield chunk
 

--- a/providers/openai_compatible_provider.py
+++ b/providers/openai_compatible_provider.py
@@ -1,0 +1,155 @@
+import time
+import logging
+from typing import AsyncIterator
+from urllib.parse import urlparse
+
+import httpx
+
+logger = logging.getLogger("switchboard.openai_compatible")
+
+from providers.base import LLMProvider
+from core.schemas import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatMessage,
+    ChatChoice,
+    Usage,
+    ProviderResult,
+)
+
+_shared_client: httpx.AsyncClient | None = None
+
+
+async def get_shared_client() -> httpx.AsyncClient:
+    global _shared_client
+    if _shared_client is None or _shared_client.is_closed:
+        _shared_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(connect=15.0, read=120.0, write=15.0, pool=15.0),
+            limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
+        )
+    return _shared_client
+
+
+class OpenAICompatibleProvider(LLMProvider):
+    def __init__(self, api_key: str, base_url: str, provider_name: str = "openai-compatible"):
+        if not base_url:
+            raise ValueError("base_url is required for openai-compatible provider")
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.provider_name = provider_name
+        self.chat_completions_url = self._build_chat_completions_url(self.base_url)
+        self.headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    @staticmethod
+    def _build_chat_completions_url(base_url: str) -> str:
+        cleaned = base_url.rstrip("/")
+        if cleaned.endswith("/chat/completions"):
+            return cleaned
+
+        parsed = urlparse(cleaned)
+        path = parsed.path.rstrip("/")
+        if path.endswith("/v1"):
+            return f"{cleaned}/chat/completions"
+
+        return f"{cleaned}/v1/chat/completions"
+
+    async def generate(self, request: ChatCompletionRequest) -> ProviderResult:
+        client = await get_shared_client()
+        payload = request.model_dump(exclude_unset=True)
+
+        start = time.time()
+        response = await client.post(
+            self.chat_completions_url,
+            headers=self.headers,
+            json=payload,
+        )
+        response.raise_for_status()
+        latency_ms = (time.time() - start) * 1000
+        data = response.json()
+
+        choices = []
+        for item in data.get("choices", []):
+            msg_data = item.get("message", {})
+            message = ChatMessage(
+                role=msg_data.get("role", "assistant"),
+                content=msg_data.get("content", ""),
+            )
+            choice = ChatChoice(
+                index=item.get("index", 0),
+                message=message,
+                finish_reason=item.get("finish_reason"),
+            )
+            choices.append(choice)
+
+        usage_data = data.get("usage", {})
+        usage = Usage(
+            prompt_tokens=usage_data.get("prompt_tokens", 0),
+            completion_tokens=usage_data.get("completion_tokens", 0),
+            total_tokens=usage_data.get("total_tokens", 0),
+        )
+
+        chat_response = ChatCompletionResponse(
+            id=data.get("id", f"chatcmpl-{int(time.time())}"),
+            created=data.get("created", int(time.time())),
+            model=data.get("model", request.model),
+            choices=choices,
+            usage=usage,
+        )
+
+        rl_headers = {
+            k.lower(): v
+            for k, v in response.headers.items()
+            if "ratelimit" in k.lower()
+        }
+
+        return ProviderResult(
+            response=chat_response,
+            provider=self.provider_name,
+            latency_ms=latency_ms,
+            rate_limit_headers=rl_headers,
+        )
+
+    async def generate_stream(self, request: ChatCompletionRequest) -> AsyncIterator[bytes]:
+        client = await get_shared_client()
+        payload = request.model_dump(exclude_unset=True)
+        payload["stream"] = True
+
+        async with client.stream(
+            "POST",
+            self.chat_completions_url,
+            headers=self.headers,
+            json=payload,
+        ) as response:
+            response.raise_for_status()
+            async for chunk in response.aiter_bytes():
+                yield chunk
+
+    async def list_models(self) -> list[dict]:
+        try:
+            models_url = self.base_url.rstrip("/")
+            if models_url.endswith("/chat/completions"):
+                models_url = models_url.replace("/chat/completions", "/models")
+            elif models_url.endswith("/v1"):
+                models_url = f"{models_url}/models"
+            else:
+                models_url = f"{models_url}/v1/models"
+            client = await get_shared_client()
+            response = await client.get(models_url, headers=self.headers)
+            response.raise_for_status()
+            data = response.json()
+            return data.get("data", [])
+        except Exception as e:
+            logger.warning(f"Failed to list models from {self.base_url}: {e}")
+            return []
+
+    async def health_check(self) -> bool:
+        return bool(self.api_key and self.base_url)
+
+    async def get_cost_per_token(self) -> dict[str, float]:
+        return {
+            "input": 0.0,
+            "output": 0.0,
+        }

--- a/routing/router.py
+++ b/routing/router.py
@@ -1,7 +1,7 @@
 """
 Router — simple key-availability-based routing.
 No cost routing, no strategy matrix. Just:
-  1. Pick the Groq key with most remaining quota
+  1. Pick the best provider key for the requested model
   2. Call the provider
   3. Update rate limits from response headers
   4. On 429 / exhaustion -> switch to next key and retry
@@ -9,7 +9,7 @@ No cost routing, no strategy matrix. Just:
 
 import logging
 import httpx
-from typing import Set
+from typing import AsyncIterator, Set
 
 from core.schemas import ChatCompletionRequest, ChatCompletionResponse, ProviderResult
 from core.key_manager import key_manager
@@ -21,14 +21,14 @@ from core.metrics import (
     TOKENS_PROCESSED,
 )
 from providers.groq_provider import GroqProvider
+from providers.openai_compatible_provider import OpenAICompatibleProvider
 
 logger = logging.getLogger("switchboard.router")
 
 
 class Router:
     def __init__(self):
-        # For MVP, only Groq is supported
-        self.provider_name = "groq"
+        self.supported_providers = {"groq", "openai-compatible"}
 
     async def route_request(self, request: ChatCompletionRequest) -> ProviderResult:
         """
@@ -37,24 +37,40 @@ class Router:
         """
         tried_key_ids: Set[int] = set()
         last_error = None
+        last_provider = None
 
         # Try up to 10 keys (practical upper bound)
-        for attempt in range(10):
+        for attempt in range(20):
             try:
-                api_key, key_id = await key_manager.get_available_key(self.provider_name)
+                api_key, key_id, provider_name, base_url, _ = await key_manager.get_available_key_for_model(
+                    model=request.model,
+                    exclude_key_ids=tried_key_ids,
+                    supported_providers=self.supported_providers,
+                )
             except RuntimeError as e:
-                raise Exception(str(e)) from e
+                last_error = e
+                break
 
             if key_id in tried_key_ids:
                 # We've cycled through all available keys
                 break
             tried_key_ids.add(key_id)
+            last_provider = provider_name
 
             if attempt > 0:
                 KEY_SWITCHES.inc()
-                logger.info(f"Switched to key id={key_id} (attempt {attempt + 1})")
+                logger.info(
+                    "Switched to key id=%s provider=%s (attempt %s)",
+                    key_id,
+                    provider_name,
+                    attempt + 1,
+                )
 
-            provider = GroqProvider(api_key=api_key)
+            provider = self._build_provider(
+                provider_name=provider_name,
+                api_key=api_key,
+                base_url=base_url,
+            )
 
             try:
                 result = await provider.generate(request)
@@ -65,9 +81,9 @@ class Router:
 
                 # Record metrics
                 PROVIDER_REQUESTS.labels(
-                    provider=self.provider_name, key_label=str(key_id), status="success"
+                    provider=provider_name, key_label=str(key_id), status="success"
                 ).inc()
-                PROVIDER_LATENCY.labels(provider=self.provider_name).observe(
+                PROVIDER_LATENCY.labels(provider=provider_name).observe(
                     result.latency_ms / 1000
                 )
                 TOKENS_PROCESSED.labels(direction="input").inc(
@@ -97,26 +113,26 @@ class Router:
                     logger.warning(f"Key id={key_id} got 429 — marking exhausted and retrying")
                     await key_manager.mark_key_exhausted(key_id)
                     PROVIDER_REQUESTS.labels(
-                        provider=self.provider_name, key_label=str(key_id), status="rate_limited"
+                        provider=provider_name, key_label=str(key_id), status="rate_limited"
                     ).inc()
                     continue
                 elif status == 401:
                     logger.warning(f"Key id={key_id} got 401 — invalid key, disabling and trying next")
                     await key_manager.toggle_key(key_id, enabled=False)
                     PROVIDER_REQUESTS.labels(
-                        provider=self.provider_name, key_label=str(key_id), status="auth_error"
+                        provider=provider_name, key_label=str(key_id), status="auth_error"
                     ).inc()
                     continue
                 elif status >= 500:
                     logger.warning(f"Key id={key_id} got {status} — trying next key")
                     PROVIDER_REQUESTS.labels(
-                        provider=self.provider_name, key_label=str(key_id), status="server_error"
+                        provider=provider_name, key_label=str(key_id), status="server_error"
                     ).inc()
                     continue
                 else:
                     # 4xx other than 429/401 — don't retry
                     PROVIDER_REQUESTS.labels(
-                        provider=self.provider_name, key_label=str(key_id), status="client_error"
+                        provider=provider_name, key_label=str(key_id), status="client_error"
                     ).inc()
                     raise
 
@@ -124,11 +140,114 @@ class Router:
                 last_error = e
                 logger.error(f"Key id={key_id} unexpected error: {e}")
                 PROVIDER_REQUESTS.labels(
-                    provider=self.provider_name, key_label=str(key_id), status="error"
+                    provider=provider_name, key_label=str(key_id), status="error"
                 ).inc()
                 continue
 
         raise Exception(
-            f"All API keys exhausted for provider '{self.provider_name}'. "
-            f"Tried {len(tried_key_ids)} key(s). Last error: {last_error}"
+            f"All API keys exhausted for model '{request.model}'. "
+            f"Tried {len(tried_key_ids)} key(s). Last provider: {last_provider}. Last error: {last_error}"
+        )
+
+    def _build_provider(self, provider_name: str, api_key: str, base_url: str | None):
+        if provider_name == "groq":
+            return GroqProvider(api_key=api_key)
+        if provider_name == "openai-compatible":
+            if not base_url:
+                raise RuntimeError(
+                    "OpenAI-compatible key is missing base_url. "
+                    "Please set base_url for this key in /admin/keys."
+                )
+            return OpenAICompatibleProvider(
+                api_key=api_key,
+                base_url=base_url,
+                provider_name=provider_name,
+            )
+        raise RuntimeError(f"Unsupported provider '{provider_name}'")
+
+    async def route_request_stream(self, request: ChatCompletionRequest) -> AsyncIterator[bytes]:
+        """
+        Streaming version of route_request.
+        Picks a key and streams SSE chunks from the provider.
+        On failure, retries with the next key.
+        """
+        tried_key_ids: Set[int] = set()
+        last_error = None
+        last_provider = None
+
+        for attempt in range(20):
+            try:
+                api_key, key_id, provider_name, base_url, _ = await key_manager.get_available_key_for_model(
+                    model=request.model,
+                    exclude_key_ids=tried_key_ids,
+                    supported_providers=self.supported_providers,
+                )
+            except RuntimeError as e:
+                last_error = e
+                break
+
+            if key_id in tried_key_ids:
+                break
+            tried_key_ids.add(key_id)
+            last_provider = provider_name
+
+            if attempt > 0:
+                KEY_SWITCHES.inc()
+                logger.info(
+                    "Switched to key id=%s provider=%s (stream attempt %s)",
+                    key_id, provider_name, attempt + 1,
+                )
+
+            provider = self._build_provider(
+                provider_name=provider_name,
+                api_key=api_key,
+                base_url=base_url,
+            )
+
+            try:
+                async for chunk in provider.generate_stream(request):
+                    yield chunk
+                PROVIDER_REQUESTS.labels(
+                    provider=provider_name, key_label=str(key_id), status="success"
+                ).inc()
+                return
+            except httpx.HTTPStatusError as e:
+                status = e.response.status_code
+                last_error = e
+                if status == 429:
+                    logger.warning(f"Key id={key_id} got 429 (stream) — marking exhausted and retrying")
+                    await key_manager.mark_key_exhausted(key_id)
+                    PROVIDER_REQUESTS.labels(
+                        provider=provider_name, key_label=str(key_id), status="rate_limited"
+                    ).inc()
+                    continue
+                elif status == 401:
+                    logger.warning(f"Key id={key_id} got 401 (stream) — disabling")
+                    await key_manager.toggle_key(key_id, enabled=False)
+                    PROVIDER_REQUESTS.labels(
+                        provider=provider_name, key_label=str(key_id), status="auth_error"
+                    ).inc()
+                    continue
+                elif status >= 500:
+                    logger.warning(f"Key id={key_id} got {status} (stream) — trying next key")
+                    PROVIDER_REQUESTS.labels(
+                        provider=provider_name, key_label=str(key_id), status="server_error"
+                    ).inc()
+                    continue
+                else:
+                    PROVIDER_REQUESTS.labels(
+                        provider=provider_name, key_label=str(key_id), status="client_error"
+                    ).inc()
+                    raise
+            except Exception as e:
+                last_error = e
+                logger.error(f"Key id={key_id} stream error: {e}")
+                PROVIDER_REQUESTS.labels(
+                    provider=provider_name, key_label=str(key_id), status="error"
+                ).inc()
+                continue
+
+        raise Exception(
+            f"All API keys exhausted for model '{request.model}' (stream). "
+            f"Tried {len(tried_key_ids)} key(s). Last provider: {last_provider}. Last error: {last_error}"
         )

--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -59,6 +59,61 @@ async def test_add_and_list_keys():
         found = [k for k in keys if k["id"] == key_id][0]
         assert "gsk_test123" not in str(found)
         assert found["api_key_masked"].startswith("gsk_")
+        assert found["base_url"] is None
+        assert found["model_cards"] == []
+
+
+@pytest.mark.asyncio
+async def test_add_openai_compatible_key():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/admin/keys",
+            json={
+                "provider": "openai-compatible",
+                "api_key": "sk_test_openai_compatible",
+                "label": "oc-1",
+                "base_url": "https://example.com/v1/",
+                "model_cards": ["gpt-4o-mini", "gpt-4.1-mini"],
+            },
+        )
+        assert resp.status_code == 200
+
+        resp = await client.get("/admin/keys?provider=openai-compatible")
+        assert resp.status_code == 200
+        keys = resp.json()["keys"]
+        assert len(keys) == 1
+        assert keys[0]["base_url"] == "https://example.com/v1"
+        assert keys[0]["model_cards"] == ["gpt-4o-mini", "gpt-4.1-mini"]
+
+
+@pytest.mark.asyncio
+async def test_add_openai_compatible_requires_base_url_and_model_cards():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/admin/keys",
+            json={
+                "provider": "openai-compatible",
+                "api_key": "sk_test_openai_compatible",
+                "label": "oc-1",
+                "model_cards": ["gpt-4o-mini"],
+            },
+        )
+        assert resp.status_code == 400
+        assert "base_url is required" in resp.text
+
+        resp = await client.post(
+            "/admin/keys",
+            json={
+                "provider": "openai-compatible",
+                "api_key": "sk_test_openai_compatible",
+                "label": "oc-1",
+                "base_url": "https://example.com/v1",
+            },
+        )
+        assert resp.status_code == 400
+        assert "model_cards is required" in resp.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_key_manager.py
+++ b/tests/test_key_manager.py
@@ -204,3 +204,79 @@ async def test_update_rate_limits(km):
     assert row["rate_limit_remaining_tokens"] == 4500
     assert row["rate_limit_remaining_requests"] == 22
     assert row["last_used_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_requires_base_url_and_model_cards(km):
+    with pytest.raises(ValueError, match="base_url is required"):
+        await km.add_key(
+            "openai-compatible",
+            "sk-openai-compatible",
+            "oc-1",
+            model_cards=["gpt-4o-mini"],
+        )
+
+    with pytest.raises(ValueError, match="model_cards is required"):
+        await km.add_key(
+            "openai-compatible",
+            "sk-openai-compatible",
+            "oc-1",
+            base_url="https://example.com/v1",
+        )
+
+
+@pytest.mark.asyncio
+async def test_add_and_list_openai_compatible_with_metadata(km):
+    key_id = await km.add_key(
+        "openai-compatible",
+        "sk-openai-compatible",
+        "oc-main",
+        base_url="https://example.com/v1/",
+        model_cards=["gpt-4o-mini", "gpt-4.1-mini", "gpt-4o-mini"],
+    )
+
+    keys = await km.list_keys(provider="openai-compatible")
+    found = next(k for k in keys if k["id"] == key_id)
+
+    assert found["base_url"] == "https://example.com/v1"
+    assert found["model_cards"] == ["gpt-4o-mini", "gpt-4.1-mini"]
+
+
+@pytest.mark.asyncio
+async def test_get_available_key_for_model_prefers_explicit_match(km):
+    wildcard_id = await km.add_key("groq", "gsk_wildcard", "groq-wildcard")
+    explicit_id = await km.add_key(
+        "openai-compatible",
+        "sk-explicit",
+        "oc-explicit",
+        base_url="https://example.com/v1",
+        model_cards=["gpt-4o-mini"],
+    )
+
+    api_key, key_id, provider, base_url, model_cards = await km.get_available_key_for_model(
+        "gpt-4o-mini",
+        supported_providers={"groq", "openai-compatible"},
+    )
+
+    assert api_key == "sk-explicit"
+    assert key_id == explicit_id
+    assert provider == "openai-compatible"
+    assert base_url == "https://example.com/v1"
+    assert model_cards == ["gpt-4o-mini"]
+    assert key_id != wildcard_id
+
+
+@pytest.mark.asyncio
+async def test_get_available_key_for_model_uses_wildcard_when_no_explicit(km):
+    key_id = await km.add_key("groq", "gsk_wildcard", "groq-wildcard")
+
+    api_key, selected_id, provider, base_url, model_cards = await km.get_available_key_for_model(
+        "llama-3.1-8b-instant",
+        supported_providers={"groq", "openai-compatible"},
+    )
+
+    assert api_key == "gsk_wildcard"
+    assert selected_id == key_id
+    assert provider == "groq"
+    assert base_url is None
+    assert model_cards == []

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -66,6 +66,12 @@ def _make_provider_result():
     )
 
 
+def _make_provider_result_for(provider_name: str):
+    result = _make_provider_result()
+    result.provider = provider_name
+    return result
+
+
 @pytest_asyncio.fixture(autouse=True)
 async def setup():
     await init_db()
@@ -152,3 +158,36 @@ async def test_router_raises_when_all_keys_exhausted():
 
         with pytest.raises(Exception, match="All API keys exhausted"):
             await router.route_request(_make_request())
+
+
+@pytest.mark.asyncio
+async def test_router_uses_openai_compatible_provider_for_matching_model():
+    """Router should pick openai-compatible key when model card explicitly matches."""
+    await key_manager.add_key("groq", "gsk_fallback", "groq-fallback")
+    await key_manager.add_key(
+        "openai-compatible",
+        "sk_openai_compat",
+        "oc-main",
+        base_url="https://example.com/v1",
+        model_cards=["gpt-4o-mini"],
+    )
+
+    router = Router()
+    request = ChatCompletionRequest(
+        model="gpt-4o-mini",
+        messages=[ChatMessage(role="user", content="Hello")],
+    )
+    mock_result = _make_provider_result_for("openai-compatible")
+
+    with patch("routing.router.OpenAICompatibleProvider") as MockOCProvider:
+        instance = MockOCProvider.return_value
+        instance.generate = AsyncMock(return_value=mock_result)
+
+        result = await router.route_request(request)
+
+        MockOCProvider.assert_called_once_with(
+            api_key="sk_openai_compat",
+            base_url="https://example.com/v1",
+            provider_name="openai-compatible",
+        )
+        assert result.provider == "openai-compatible"

--- a/vis/index.html
+++ b/vis/index.html
@@ -933,6 +933,40 @@ body::after {
 
 .modal p { color: var(--text-secondary); font-size: 0.85rem; margin-bottom: var(--space-lg); }
 
+.modal-edit {
+  background: var(--bg-surface);
+  border: 1px solid var(--amber);
+  border-radius: var(--radius-md);
+  padding: var(--space-xl);
+  max-width: 520px;
+  text-align: left;
+  box-shadow: 0 0 30px rgba(212,160,23,0.15);
+}
+
+.modal-edit h3 {
+  font-family: var(--font-display);
+  color: var(--amber);
+  margin-bottom: var(--space-lg);
+}
+
+.modal-edit .form-group {
+  margin-bottom: var(--space-md);
+}
+
+.modal-edit .form-label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--text-dim);
+  margin-bottom: var(--space-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.modal-edit .form-input,
+.modal-edit .form-select {
+  width: 100%;
+}
+
 .modal-actions {
   display: flex;
   justify-content: center;
@@ -1036,7 +1070,7 @@ body::after {
 
     <div class="sidebar-footer">
       Auto-refreshes every 10s<br>
-      <kbd>1</kbd> <kbd>2</kbd> <kbd>3</kbd> — switch tabs
+      <kbd>1</kbd> <kbd>2</kbd> <kbd>3</kbd> <kbd>4</kbd> — switch tabs
     </div>
   </aside>
 
@@ -1053,6 +1087,9 @@ body::after {
       </button>
       <button class="tab-btn" data-tab="usage" role="tab" aria-selected="false">
         <span class="tab-icon"><svg class="icon" viewBox="0 0 24 24"><path d="M18 20V10M12 20V4M6 20v-6"/></svg></span> Key Usage
+      </button>
+      <button class="tab-btn" data-tab="cache" role="tab" aria-selected="false">
+        <span class="tab-icon"><svg class="icon" viewBox="0 0 24 24"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/><polyline points="3.27 6.96 12 12.01 20.73 6.96"/><line x1="12" y1="22.08" x2="12" y2="12"/></svg></span> Cache Settings
       </button>
     </nav>
   </header>
@@ -1085,6 +1122,25 @@ body::after {
         <div class="form-group">
           <label class="form-label" for="q-user">User Prompt</label>
           <textarea class="form-textarea" id="q-user" rows="3" placeholder="Ask something…">What is the capital of France?</textarea>
+        </div>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label class="form-label" for="q-similarity">Similarity</label>
+            <select class="form-select" id="q-similarity">
+              <option value="">Default (balanced)</option>
+              <option value="strict">Strict (0.95)</option>
+              <option value="balanced">Balanced (0.9)</option>
+              <option value="aggressive">Aggressive (0.6)</option>
+            </select>
+          </div>
+          <div class="form-group">
+            <label class="form-label" for="q-model-use">Use Model</label>
+            <select class="form-select" id="q-model-use">
+              <option value="true">Yes — call model on miss</option>
+              <option value="false">No — cache only</option>
+            </select>
+          </div>
         </div>
 
         <button class="btn btn-primary" id="btn-send-query">
@@ -1219,6 +1275,54 @@ body::after {
       </div>
     </section>
 
+    <!-- =========== TAB 4: CACHE SETTINGS =========== -->
+    <section class="tab-panel" id="panel-cache">
+      <h2 class="section-title">Cache Settings</h2>
+
+      <div class="card riveted" style="max-width: 640px; margin-bottom: var(--space-xl);">
+        <div class="section-subtitle">Configuration</div>
+
+        <div class="form-row">
+          <div class="form-group">
+            <label class="form-label" for="cs-ttl">Cache TTL (seconds)</label>
+            <input class="form-input" id="cs-ttl" type="number" min="1" step="1" placeholder="3600">
+          </div>
+          <div class="form-group">
+            <label class="form-label" for="cs-threshold">Similarity Threshold</label>
+            <input class="form-input" id="cs-threshold" type="number" min="0" max="1" step="0.01" placeholder="0.9">
+          </div>
+        </div>
+
+        <div style="display:flex;gap:var(--space-md);align-items:center;">
+          <button class="btn btn-primary" id="btn-save-cache-config">Save Config</button>
+          <button class="btn btn-secondary" id="btn-refresh-cache-config">↻ Refresh</button>
+        </div>
+      </div>
+
+      <div class="card riveted" style="max-width: 640px; margin-bottom: var(--space-xl);">
+        <div class="section-subtitle">Cache Stats</div>
+
+        <div class="metric-row" id="cache-stats-metrics">
+          <div class="metric-card"><div class="metric-label">Cached Entries</div><div class="metric-value neutral" id="csm-entries">—</div></div>
+          <div class="metric-card"><div class="metric-label">TTL</div><div class="metric-value neutral" id="csm-ttl">—</div></div>
+          <div class="metric-card"><div class="metric-label">Threshold</div><div class="metric-value neutral" id="csm-threshold">—</div></div>
+        </div>
+
+        <div style="margin-top:var(--space-md);">
+          <div class="section-subtitle">Similarity Presets</div>
+          <div style="display:flex;gap:var(--space-md);flex-wrap:wrap;" id="cache-presets"></div>
+        </div>
+      </div>
+
+      <div class="card riveted" style="max-width: 640px;">
+        <div class="section-subtitle">Danger Zone</div>
+        <p style="font-size:0.82rem;color:var(--text-secondary);margin-bottom:var(--space-md);">
+          Flushing the cache will delete all cached responses immediately. This cannot be undone.
+        </p>
+        <button class="btn btn-danger" id="btn-flush-cache">Flush All Cache Entries</button>
+      </div>
+    </section>
+
   </main>
 </div>
 
@@ -1233,6 +1337,49 @@ body::after {
     <div class="modal-actions">
       <button class="btn btn-secondary btn-sm" id="btn-cancel-delete">Cancel</button>
       <button class="btn btn-danger btn-sm" id="btn-confirm-delete">Delete</button>
+    </div>
+  </div>
+</div>
+
+<!-- Edit key modal -->
+<div class="modal-backdrop" id="edit-modal">
+  <div class="modal-edit">
+    <h3>Edit Key</h3>
+    <input type="hidden" id="ek-id">
+    <div class="form-row">
+      <div class="form-group">
+        <label class="form-label" for="ek-provider">Provider</label>
+        <select class="form-select" id="ek-provider">
+          <option value="groq">Groq</option>
+          <option value="openai-compatible">OpenAI Compatible</option>
+          <option value="openai">OpenAI</option>
+          <option value="anthropic">Anthropic</option>
+          <option value="google">Google</option>
+          <option value="local">Local</option>
+        </select>
+      </div>
+      <div class="form-group">
+        <label class="form-label" for="ek-label">Label</label>
+        <input class="form-input" id="ek-label" type="text" placeholder="e.g. prod-key-1">
+      </div>
+    </div>
+    <div class="form-group">
+      <label class="form-label" for="ek-key">API Key (leave blank to keep current)</label>
+      <input class="form-input" id="ek-key" type="password" placeholder="Enter new key or leave blank">
+    </div>
+    <div id="ek-openai-extra" style="display:none;">
+      <div class="form-group">
+        <label class="form-label" for="ek-base-url">Base URL</label>
+        <input class="form-input" id="ek-base-url" type="text" placeholder="https://your-endpoint/v1">
+      </div>
+      <div class="form-group">
+        <label class="form-label" for="ek-model-cards">Model Cards (comma-separated)</label>
+        <input class="form-input" id="ek-model-cards" type="text" placeholder="gpt-4o-mini, llama-3.1-8b-instant">
+      </div>
+    </div>
+    <div class="modal-actions" style="margin-top:var(--space-lg);">
+      <button class="btn btn-secondary btn-sm" id="btn-cancel-edit">Cancel</button>
+      <button class="btn btn-primary btn-sm" id="btn-save-edit">Save Changes</button>
     </div>
   </div>
 </div>
@@ -1372,6 +1519,7 @@ function initTabs() {
     if (e.key === '1') switchTab('query');
     if (e.key === '2') switchTab('keys');
     if (e.key === '3') switchTab('usage');
+    if (e.key === '4') switchTab('cache');
   });
 }
 
@@ -1385,6 +1533,7 @@ function switchTab(tab) {
   // Lazy-load data
   if (tab === 'keys') loadKeys();
   if (tab === 'usage') loadUsage();
+  if (tab === 'cache') loadCacheConfig();
 }
 
 /* =====================================================================
@@ -1423,6 +1572,11 @@ async function sendQuery() {
     stream: false,
   };
 
+  const similarity = $('#q-similarity').value;
+  const modelUse = $('#q-model-use').value;
+  if (similarity) payload.similarity = similarity;
+  if (modelUse === 'false') payload.model_use = false;
+
   const t0 = performance.now();
   try {
     const res = await fetch(`${API_BASE}/v1/chat/completions`, {
@@ -1446,10 +1600,20 @@ async function sendQuery() {
 
     const xCache = res.headers.get('X-Cache');
     const xSim = res.headers.get('X-Semantic-Similarity');
-    const isCached = xCache ? xCache === 'HIT' : parseFloat(latency) < 0.2;
+    const xFallback = res.headers.get('X-Fallback-Reason');
+    const xModelUse = res.headers.get('X-Model-Use');
+    const isCached = xCache === 'HIT' || xCache === 'FALLBACK' || (!xCache && parseFloat(latency) < 0.2);
     const tokens = data?.usage?.total_tokens ?? '—';
 
-    // Render metrics
+    let sourceBadge;
+    if (xCache === 'FALLBACK') {
+      sourceBadge = '<span class="badge" style="background:rgba(192,57,43,0.15);color:#e74c3c;border:1px solid rgba(192,57,43,0.25);">⚠ Fallback</span>';
+    } else if (isCached) {
+      sourceBadge = '<span class="badge badge-cache"><svg class="icon" viewBox="0 0 24 24" style="width:12px;height:12px;stroke:currentColor;fill:none;stroke-width:2;"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg> Cache</span>';
+    } else {
+      sourceBadge = '<span class="badge badge-model"><svg class="icon" viewBox="0 0 24 24" style="width:12px;height:12px;stroke:currentColor;fill:none;stroke-width:2;"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg> Model</span>';
+    }
+
     const metricsHtml = `
       <div class="metric-card">
         <div class="metric-label">Latency</div>
@@ -1458,9 +1622,8 @@ async function sendQuery() {
       <div class="metric-card">
         <div class="metric-label">Source</div>
         <div class="metric-value" style="font-size:1rem;">
-          ${isCached
-            ? '<span class="badge badge-cache"><svg class="icon" viewBox="0 0 24 24" style="width:12px;height:12px;stroke:currentColor;fill:none;stroke-width:2;"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg> Cache</span>'
-            : '<span class="badge badge-model"><svg class="icon" viewBox="0 0 24 24" style="width:12px;height:12px;stroke:currentColor;fill:none;stroke-width:2;"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4M12 8h.01"/></svg> Model</span>'}
+          ${sourceBadge}
+          ${xModelUse === 'false' ? '<span class="badge" style="background:rgba(74,158,140,0.15);color:#6bc9b4;border:1px solid rgba(74,158,140,0.25);">Cache-only</span>' : ''}
         </div>
       </div>
       <div class="metric-card">
@@ -1561,6 +1724,7 @@ function renderKeys() {
             <input type="checkbox" ${k.is_enabled ? 'checked' : ''} onchange="toggleKey(${k.id}, this.checked)">
             <span class="toggle-slider"></span>
           </label>
+          <button class="btn btn-secondary btn-sm" onclick="openEditModal(${k.id})" title="Edit key">✎</button>
           <button class="btn btn-danger btn-sm" onclick="confirmDelete(${k.id})" title="Delete key">✕</button>
         </div>
       </div>
@@ -1667,6 +1831,72 @@ async function addKey() {
 
   btn.disabled = false;
   btn.textContent = 'Add Key';
+}
+
+/* =====================================================================
+    EDIT KEY
+    ===================================================================== */
+function openEditModal(keyId) {
+  const k = state.keys.find(k => k.id === keyId);
+  if (!k) { toast('Key not found', 'error'); return; }
+
+  $('#ek-id').value = k.id;
+  $('#ek-provider').value = k.provider || 'groq';
+  $('#ek-label').value = k.label || '';
+  $('#ek-key').value = '';
+  $('#ek-base-url').value = k.base_url || '';
+  $('#ek-model-cards').value = Array.isArray(k.model_cards) ? k.model_cards.join(', ') : '';
+
+  syncEditProviderFields();
+  $('#edit-modal').classList.add('visible');
+}
+
+function syncEditProviderFields() {
+  const provider = $('#ek-provider').value;
+  $('#ek-openai-extra').style.display = provider === 'openai-compatible' ? 'block' : 'none';
+}
+
+async function saveEditKey() {
+  const keyId = parseInt($('#ek-id').value, 10);
+  const provider = $('#ek-provider').value;
+  const label = $('#ek-label').value.trim();
+  const apiKey = $('#ek-key').value.trim();
+  const baseUrl = $('#ek-base-url').value.trim();
+  const modelCardsRaw = $('#ek-model-cards').value.trim();
+
+  const payload = {};
+  if (provider) payload.provider = provider;
+  if (label) payload.label = label;
+  if (apiKey) payload.api_key = apiKey;
+  if (provider === 'openai-compatible') {
+    if (baseUrl) payload.base_url = baseUrl;
+    const cards = modelCardsRaw.split(',').map(c => c.trim()).filter(Boolean);
+    if (cards.length) payload.model_cards = cards;
+  } else {
+    if (baseUrl) payload.base_url = baseUrl;
+    if (modelCardsRaw) payload.model_cards = modelCardsRaw.split(',').map(c => c.trim()).filter(Boolean);
+  }
+
+  if (!Object.keys(payload).length) { toast('No changes to save', 'error'); return; }
+
+  const btn = $('#btn-save-edit');
+  btn.disabled = true;
+  btn.innerHTML = '<span class="spinner"></span> Saving…';
+
+  try {
+    const res = await api('PUT', `/admin/keys/${keyId}`, payload);
+    if (res.ok) {
+      toast('Key updated');
+      $('#edit-modal').classList.remove('visible');
+      loadKeys();
+    } else {
+      const errText = await res.text();
+      toast(`Update failed: ${errText}`, 'error');
+    }
+  } catch (e) { toast(`Request failed: ${e.message}`, 'error'); }
+
+  btn.disabled = false;
+  btn.textContent = 'Save Changes';
 }
 
 /* =====================================================================
@@ -1781,20 +2011,113 @@ function renderUsage() {
 }
 
 /* =====================================================================
+   TAB 4: CACHE SETTINGS
+   ===================================================================== */
+function initCache() {
+  $('#btn-save-cache-config').addEventListener('click', saveCacheConfig);
+  $('#btn-refresh-cache-config').addEventListener('click', loadCacheConfig);
+  $('#btn-flush-cache').addEventListener('click', async () => {
+    if (!confirm('Flush ALL cached entries? This cannot be undone.')) return;
+    await flushCache();
+  });
+}
+
+async function loadCacheConfig() {
+  if (!state.backendOk) return;
+  try {
+    const res = await api('GET', '/admin/cache/config');
+    if (!res.ok) return;
+    const data = await res.json();
+
+    $('#cs-ttl').value = data.ttl ?? '';
+    $('#cs-threshold').value = data.similarity_threshold ?? '';
+    $('#csm-entries').textContent = data.entry_count ?? '—';
+    $('#csm-ttl').textContent = data.ttl ? `${data.ttl}s` : '—';
+    $('#csm-threshold').textContent = data.similarity_threshold ?? '—';
+
+    if (data.presets) {
+      $('#cache-presets').innerHTML = Object.entries(data.presets).map(([name, val]) =>
+        `<div class="metric-card"><div class="metric-label">${name}</div><div class="metric-value neutral">${val}</div></div>`
+      ).join('');
+    }
+  } catch { toast('Failed to load cache config', 'error'); }
+}
+
+async function saveCacheConfig() {
+  const ttl = $('#cs-ttl').value ? parseInt($('#cs-ttl').value, 10) : undefined;
+  const threshold = $('#cs-threshold').value ? parseFloat($('#cs-threshold').value) : undefined;
+
+  const payload = {};
+  if (ttl !== undefined && !isNaN(ttl)) payload.ttl = ttl;
+  if (threshold !== undefined && !isNaN(threshold)) payload.similarity_threshold = threshold;
+
+  if (!Object.keys(payload).length) { toast('No changes to save', 'error'); return; }
+
+  const btn = $('#btn-save-cache-config');
+  btn.disabled = true;
+  btn.innerHTML = '<span class="spinner"></span> Saving…';
+
+  try {
+    const res = await api('PUT', '/admin/cache/config', payload);
+    if (res.ok) {
+      toast('Cache config saved');
+      await loadCacheConfig();
+    } else {
+      const err = await res.text();
+      toast(`Save failed: ${err}`, 'error');
+    }
+  } catch { toast('Request failed', 'error'); }
+
+  btn.disabled = false;
+  btn.textContent = 'Save Config';
+}
+
+async function flushCache() {
+  const btn = $('#btn-flush-cache');
+  btn.disabled = true;
+  btn.innerHTML = '<span class="spinner"></span> Flushing…';
+
+  try {
+    const res = await api('POST', '/admin/cache/flush');
+    if (res.ok) {
+      const data = await res.json();
+      toast(`Flushed ${data.deleted_count ?? 0} entries`);
+      await loadCacheConfig();
+    } else {
+      toast('Flush failed', 'error');
+    }
+  } catch { toast('Request failed', 'error'); }
+
+  btn.disabled = false;
+  btn.textContent = 'Flush All Cache Entries';
+}
+
+/* =====================================================================
    DELETE MODAL
    ===================================================================== */
 function initModals() {
+  // Delete modal
   $('#btn-cancel-delete').addEventListener('click', () => {
     $('#delete-modal').classList.remove('visible');
     state.deleteTargetId = null;
   });
   $('#btn-confirm-delete').addEventListener('click', executeDelete);
-
-  // Close on backdrop click
   $('#delete-modal').addEventListener('click', e => {
     if (e.target === e.currentTarget) {
       e.currentTarget.classList.remove('visible');
       state.deleteTargetId = null;
+    }
+  });
+
+  // Edit modal
+  $('#btn-cancel-edit').addEventListener('click', () => {
+    $('#edit-modal').classList.remove('visible');
+  });
+  $('#btn-save-edit').addEventListener('click', saveEditKey);
+  $('#ek-provider').addEventListener('change', syncEditProviderFields);
+  $('#edit-modal').addEventListener('click', e => {
+    if (e.target === e.currentTarget) {
+      e.currentTarget.classList.remove('visible');
     }
   });
 }
@@ -1807,6 +2130,7 @@ async function init() {
   initQuery();
   initKeys();
   initUsage();
+  initCache();
   initModals();
 
   // Initial health check

--- a/vis/index.html
+++ b/vis/index.html
@@ -644,6 +644,7 @@ body::after {
 
 .badge-groq    { background: rgba(255,107,53,0.15); color: #ff8a50; border: 1px solid rgba(255,107,53,0.25); }
 .badge-openai  { background: rgba(74,158,140,0.15); color: #6bc9b4; border: 1px solid rgba(74,158,140,0.25); }
+.badge-openai-compatible { background: rgba(74,158,140,0.15); color: #6bc9b4; border: 1px solid rgba(74,158,140,0.25); }
 .badge-anthropic { background: rgba(180,130,90,0.15); color: #d4a76a; border: 1px solid rgba(180,130,90,0.25); }
 .badge-local   { background: rgba(130,130,170,0.15); color: #a0a0cc; border: 1px solid rgba(130,130,170,0.25); }
 .badge-google  { background: rgba(66,133,244,0.15); color: #82b1f5; border: 1px solid rgba(66,133,244,0.25); }
@@ -700,6 +701,7 @@ body::after {
 
 .key-item.provider-groq    { border-left-color: #ff6b35; }
 .key-item.provider-openai  { border-left-color: #4a9e8c; }
+.key-item.provider-openai-compatible  { border-left-color: #4a9e8c; }
 .key-item.provider-anthropic { border-left-color: #b4825a; }
 .key-item.provider-local   { border-left-color: #8282aa; }
 .key-item.provider-google  { border-left-color: #4285f4; }
@@ -1120,6 +1122,7 @@ body::after {
             <label class="form-label" for="ak-provider">Provider</label>
             <select class="form-select" id="ak-provider">
               <option value="groq">Groq</option>
+              <option value="openai-compatible">OpenAI Compatible</option>
               <option value="openai">OpenAI</option>
               <option value="anthropic">Anthropic</option>
               <option value="google">Google</option>
@@ -1134,6 +1137,16 @@ body::after {
         <div class="form-group">
           <label class="form-label" for="ak-key">API Key</label>
           <input class="form-input" id="ak-key" type="password" placeholder="sk-…">
+        </div>
+        <div id="openai-compatible-extra" style="display:none; margin-top: var(--space-md);">
+          <div class="form-group">
+            <label class="form-label" for="ak-base-url">Base URL (OpenAI-compatible)</label>
+            <input class="form-input" id="ak-base-url" type="text" placeholder="https://your-endpoint/v1">
+          </div>
+          <div class="form-group">
+            <label class="form-label" for="ak-model-cards">Model Cards (comma-separated)</label>
+            <input class="form-input" id="ak-model-cards" type="text" placeholder="gpt-4o-mini, llama-3.1-8b-instant">
+          </div>
         </div>
         <button class="btn btn-primary" id="btn-add-key">Add Key</button>
       </div>
@@ -1478,6 +1491,14 @@ async function sendQuery() {
 function initKeys() {
   $('#btn-add-key').addEventListener('click', addKey);
   $('#btn-refresh-keys').addEventListener('click', loadKeys);
+  $('#ak-provider').addEventListener('change', syncProviderSpecificFields);
+  syncProviderSpecificFields();
+}
+
+function syncProviderSpecificFields() {
+  const provider = $('#ak-provider').value;
+  const isOpenAICompatible = provider === 'openai-compatible';
+  $('#openai-compatible-extra').style.display = isOpenAICompatible ? 'block' : 'none';
 }
 
 async function loadKeys() {
@@ -1549,6 +1570,8 @@ function renderKeys() {
           <div class="key-detail-item"><div class="kd-label">Remaining Requests</div><div class="kd-value">${k.rate_limit_remaining_requests != null ? formatNum(k.rate_limit_remaining_requests) : '—'}</div></div>
           <div class="key-detail-item"><div class="kd-label">Token Reset</div><div class="kd-value">${k.rate_limit_reset_tokens || '—'}</div></div>
           <div class="key-detail-item"><div class="kd-label">Request Reset</div><div class="kd-value">${k.rate_limit_reset_requests || '—'}</div></div>
+          <div class="key-detail-item"><div class="kd-label">Base URL</div><div class="kd-value">${k.base_url || '—'}</div></div>
+          <div class="key-detail-item"><div class="kd-label">Model Cards</div><div class="kd-value">${Array.isArray(k.model_cards) && k.model_cards.length ? k.model_cards.join(', ') : '—'}</div></div>
         </div>
         <div class="key-timestamps">
           Last used: ${k.last_used_at || 'never'} &nbsp;·&nbsp; Created: ${k.created_at || '—'}
@@ -1600,20 +1623,41 @@ async function addKey() {
   const provider = $('#ak-provider').value;
   const label = $('#ak-label').value.trim();
   const apiKey = $('#ak-key').value.trim();
+  const baseUrl = $('#ak-base-url').value.trim();
+  const modelCardsRaw = $('#ak-model-cards').value.trim();
 
   if (!apiKey) { toast('API key cannot be empty', 'error'); return; }
+
+  let base_url = null;
+  let model_cards = null;
+  if (provider === 'openai-compatible') {
+    if (!baseUrl) { toast('Base URL is required for OpenAI-compatible keys', 'error'); return; }
+    const cards = modelCardsRaw
+      .split(',')
+      .map(c => c.trim())
+      .filter(Boolean);
+    if (!cards.length) { toast('At least one model card is required', 'error'); return; }
+    base_url = baseUrl;
+    model_cards = cards;
+  }
 
   const btn = $('#btn-add-key');
   btn.disabled = true;
   btn.innerHTML = '<span class="spinner"></span> Adding…';
 
   try {
-    const res = await api('POST', '/admin/keys', { provider, api_key: apiKey, label });
+    const payload = { provider, api_key: apiKey, label };
+    if (base_url) payload.base_url = base_url;
+    if (model_cards) payload.model_cards = model_cards;
+
+    const res = await api('POST', '/admin/keys', payload);
     if (res.ok) {
       const data = await res.json();
       toast(`Key added (ID: ${data.id})`);
       $('#ak-label').value = '';
       $('#ak-key').value = '';
+      $('#ak-base-url').value = '';
+      $('#ak-model-cards').value = '';
       loadKeys();
     } else {
       const errText = await res.text();


### PR DESCRIPTION
## Summary

- Add SSE streaming passthrough with proper error handling (pre-flight first chunk, upstream status check)
- Add `/v1/models` endpoint for OpenAI client compatibility
- Add `POST /admin/discover-models/{key_id}` endpoint for model auto-discovery
- Fix Pydantic schemas: `extra="allow"` on request/message models, `content` accepts `str | List` for multimodal
- Fix connection reset from per-request `httpx.AsyncClient` by using shared persistent client singletons
- Add `generate_stream()` to base provider and both provider implementations with key rotation/retry
- Update admin UI with model discovery support
- Add test scripts to `.gitignore`

## Test plan

- [x] `GET /v1/models` returns model list
- [x] Non-streaming `POST /v1/chat/completions` returns 200 with valid response
- [x] Streaming `POST /v1/chat/completions` with `stream: true` returns 200 with SSE chunks
- [x] Upstream errors during streaming return 502 instead of connection reset
- [x] Docker rebuild and smoke test passed