### PR TITLE
feat: add multi-provider routing with per-request selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ SwitchBoard sits between your client applications and upstream LLM providers, of
 - **OpenAI-Compatible API** — Drop-in `/v1/chat/completions` endpoint that works with any OpenAI client library.
 - **Semantic Caching** — Embedding-based similarity cache (powered by Google Gemini embeddings + Redis) that returns cached responses for semantically similar prompts, saving tokens and latency.
 - **Automatic Key Rotation** — Register multiple API keys per provider; the router picks the key with the most remaining quota and automatically fails over on 429 rate limits or auth errors.
+- **Per-Request Provider Selection** — Optionally set `provider` in the request body to target a specific vendor.
 - **Encrypted Key Storage** — API keys are encrypted at rest with Fernet (AES-128-CBC) and stored in SQLite.
 - **Rate-Limit Awareness** — Parses provider rate-limit headers in real time, tracks per-key quotas, and runs a background sweeper to reset expired windows.
 - **Admin API & Dashboard** — Full CRUD for API keys, provider health summaries, and stats via REST endpoints + a retro-industrial web dashboard (static HTML/CSS/JS served by nginx).
@@ -25,7 +26,7 @@ SwitchBoard sits between your client applications and upstream LLM providers, of
 | API Framework       | FastAPI + Uvicorn                           |
 | Cache               | Redis 7 (async via `redis-py`)              |
 | Embeddings          | Google Gemini (`gemini-embedding-001`)      |
-| LLM Provider        | Groq (OpenAI-compatible)                    |
+| LLM Provider        | Groq, Google, Anthropic                      |
 | Key Storage         | SQLite + Fernet encryption (`cryptography`) |
 | Schemas / Validation| Pydantic v2                                 |
 | Admin UI            | Static HTML/CSS/JS + nginx (reverse proxy)  |
@@ -81,6 +82,7 @@ SwitchBoard sits between your client applications and upstream LLM providers, of
 - **Redis** (included via Docker Compose, or run standalone)
 - A **Groq** API key (get one at [console.groq.com](https://console.groq.com))
 - A **Google AI** API key for embeddings (get one at [aistudio.google.com](https://aistudio.google.com))
+- Optional: **Google** and **Anthropic** API keys for provider routing
 
 ---
 
@@ -112,6 +114,7 @@ Populate it with:
 ```env
 GROQ_API_KEY=gsk_...
 GOOGLE_API_KEY=AIza...
+ANTHROPIC_API_KEY=sk-ant-...
 ENCRYPTION_KEY=<key-from-step-2>
 ```
 
@@ -166,6 +169,7 @@ redis-server
 ```bash
 export GROQ_API_KEY="gsk_..."
 export GOOGLE_API_KEY="AIza..."
+export ANTHROPIC_API_KEY="sk-ant-..."
 export ENCRYPTION_KEY="$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')"
 export REDIS_URL="redis://localhost:6379/0"
 ```
@@ -193,7 +197,8 @@ curl -X POST http://localhost:8000/v1/chat/completions \
       {"role": "system", "content": "You are a helpful assistant."},
       {"role": "user", "content": "What is the capital of France?"}
     ],
-    "temperature": 0.7
+    "temperature": 0.7,
+    "provider": "groq"
   }'
 ```
 
@@ -278,6 +283,7 @@ pytest
 
 # Run a specific test file
 pytest tests/test_routing.py
+pytest tests/test_provider_routing.py
 
 # Run with verbose output
 pytest -v
@@ -291,6 +297,7 @@ Test modules:
 | `tests/test_key_manager.py` | Key encryption, rotation, rate limits|
 | `tests/test_routing.py`     | Router failover and key selection    |
 | `tests/test_semantic_cache.py` | Embedding-based cache logic       |
+| `tests/test_provider_routing.py` | Provider selection via request  |
 | `tests/test_token_exhaustion.py` | Rate-limit exhaustion scenarios |
 
 ---
@@ -340,6 +347,8 @@ switchboard/
 | `ENCRYPTION_KEY`  | Yes      | —                          | Fernet key for encrypting API keys at rest        |
 | `GROQ_API_KEY`    | No       | `""`                       | Default Groq key (can also add via Admin API)     |
 | `GOOGLE_API_KEY`  | No       | `""`                       | Google AI key for embedding generation            |
+| `ANTHROPIC_API_KEY` | No     | `""`                       | Anthropic API key for provider routing            |
+| `SWITCHBOARD_PROVIDER` | No  | `"groq"`                  | Default provider when request omits `provider`    |
 | `REDIS_URL`       | No       | `redis://localhost:6379/0` | Redis connection URL                              |
 | `SQLITE_DB_PATH`  | No       | `data/switchboard.db`      | Path to the SQLite database file                  |
 | `PORT`            | No       | `8000`                     | Gateway listen port                               |

--- a/core/config.py
+++ b/core/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     # Provider keys (optional — prefer adding via Admin UI / DB)
     GROQ_API_KEY: str = ""
     GOOGLE_API_KEY: str = ""
+    ANTHROPIC_API_KEY: str = ""
 
     # Redis
     REDIS_URL: str = "redis://localhost:6379/0"
@@ -12,6 +13,9 @@ class Settings(BaseSettings):
     # Gateway
     PORT: int = 8000
     HOST: str = "0.0.0.0"
+
+    # Router
+    SWITCHBOARD_PROVIDER: str = "groq"
 
     # SQLite config store
     SQLITE_DB_PATH: str = "data/switchboard.db"

--- a/core/key_manager.py
+++ b/core/key_manager.py
@@ -123,6 +123,8 @@ class KeyManager:
         )
         await db.commit()
         key_id = cursor.lastrowid
+        if key_id is None:
+            raise RuntimeError("Failed to insert API key: no row id returned")
         logger.info(f"Added key id={key_id} provider={provider} label={label}")
         return key_id
 
@@ -216,6 +218,31 @@ class KeyManager:
 
         raise RuntimeError(f"No enabled API keys available for provider '{provider}'")
 
+    async def get_all_keys(self, provider: str) -> List[Tuple[str, int]]:
+        """
+        Return all enabled keys for a provider, regardless of exhaustion state.
+        Returns list of (decrypted_api_key, key_id).
+        """
+        db = await get_db()
+        cursor = await db.execute(
+            """
+            SELECT id, api_key_encrypted
+            FROM api_keys
+            WHERE provider = ? AND is_enabled = 1
+            ORDER BY id
+            """,
+            (provider.lower(),),
+        )
+        rows = await cursor.fetchall()
+        if not rows:
+            raise RuntimeError(f"No enabled API keys available for provider '{provider}'")
+
+        results: List[Tuple[str, int]] = []
+        for row in rows:
+            plain = decrypt_key(row["api_key_encrypted"])
+            results.append((plain, row["id"]))
+        return results
+
     # ---- rate-limit updates ----
 
     async def update_rate_limits(self, key_id: int, headers: dict):
@@ -272,7 +299,7 @@ class KeyManager:
             "SELECT COUNT(*) as cnt FROM api_keys WHERE provider = 'groq'"
         )
         row = await cursor.fetchone()
-        if row["cnt"] == 0:
+        if row is not None and row["cnt"] == 0:
             await self.add_key("groq", settings.GROQ_API_KEY, "env-default")
             logger.info("Seeded GROQ_API_KEY from environment into database.")
 

--- a/core/schemas.py
+++ b/core/schemas.py
@@ -10,6 +10,7 @@ class ChatCompletionRequest(BaseModel):
     messages: List[ChatMessage]
     temperature: Optional[float] = 0.7
     stream: Optional[bool] = False
+    provider: Optional[str] = None
 
 class Usage(BaseModel):
     prompt_tokens: int = 0

--- a/providers/anthropic_provider.py
+++ b/providers/anthropic_provider.py
@@ -1,0 +1,114 @@
+import time
+import httpx
+from typing import Dict
+
+from providers.base import LLMProvider
+from core.schemas import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatMessage,
+    ChatChoice,
+    Usage,
+    ProviderResult,
+)
+from core.config import settings
+
+
+class AnthropicProvider(LLMProvider):
+    def __init__(self, api_key: str | None = None):
+        self.api_key = api_key or getattr(settings, "ANTHROPIC_API_KEY", "")
+        self.base_url = "https://api.anthropic.com/v1/messages"
+        self.headers = {
+            "x-api-key": self.api_key,
+            "anthropic-version": "2023-06-01",
+            "content-type": "application/json",
+        }
+
+    async def generate(self, request: ChatCompletionRequest) -> ProviderResult:
+        async with httpx.AsyncClient() as client:
+            payload = self._build_payload(request)
+
+            start = time.time()
+            response = await client.post(
+                self.base_url,
+                headers=self.headers,
+                json=payload,
+                timeout=30.0,
+            )
+            response.raise_for_status()
+            latency_ms = (time.time() - start) * 1000
+            data = response.json()
+
+            message_content = ""
+            content_blocks = data.get("content", [])
+            if content_blocks:
+                first_block = content_blocks[0]
+                message_content = first_block.get("text", "")
+
+            choices = [
+                ChatChoice(
+                    index=0,
+                    message=ChatMessage(role="assistant", content=message_content),
+                    finish_reason=data.get("stop_reason"),
+                )
+            ]
+
+            usage_data = data.get("usage", {})
+            usage = Usage(
+                prompt_tokens=usage_data.get("input_tokens", 0),
+                completion_tokens=usage_data.get("output_tokens", 0),
+                total_tokens=usage_data.get("input_tokens", 0)
+                + usage_data.get("output_tokens", 0),
+            )
+
+            chat_response = ChatCompletionResponse(
+                id=data.get("id", f"chatcmpl-{int(time.time())}"),
+                created=int(time.time()),
+                model=data.get("model", request.model),
+                choices=choices,
+                usage=usage,
+            )
+
+            rl_headers = {
+                k: v
+                for k, v in response.headers.items()
+                if k.lower().startswith("x-ratelimit")
+            }
+
+            return ProviderResult(
+                response=chat_response,
+                provider="anthropic",
+                latency_ms=latency_ms,
+                rate_limit_headers=rl_headers,
+            )
+
+    def _build_payload(self, request: ChatCompletionRequest) -> dict:
+        messages = []
+        system_text = None
+        for msg in request.messages:
+            if msg.role == "system" and system_text is None:
+                system_text = msg.content
+                continue
+            messages.append({"role": msg.role, "content": msg.content})
+
+        payload = {
+            "model": request.model,
+            "messages": messages,
+            "max_tokens": 1024,
+        }
+        if request.temperature is not None:
+            payload["temperature"] = request.temperature
+        if system_text:
+            payload["system"] = system_text
+        return payload
+
+    async def health_check(self) -> bool:
+        if not self.api_key:
+            return False
+        return True
+
+    async def get_cost_per_token(self) -> Dict[str, float]:
+        return {
+            "input": 0.0,
+            "output": 0.0,
+        }

--- a/providers/google_provider.py
+++ b/providers/google_provider.py
@@ -1,88 +1,93 @@
 import time
 import httpx
-from typing import Dict, Any
+from typing import Dict
 
 from providers.base import LLMProvider
-from core.schemas import ChatCompletionRequest, ChatCompletionResponse, ChatMessage, ChatChoice, Usage, ProviderResult
+from core.schemas import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatMessage,
+    ChatChoice,
+    Usage,
+    ProviderResult,
+)
 from core.config import settings
 
-class GroqProvider(LLMProvider):
+
+class GoogleProvider(LLMProvider):
     def __init__(self, api_key: str | None = None):
-        self.api_key = api_key or settings.GROQ_API_KEY
-        self.base_url = "https://api.groq.com/openai/v1/chat/completions"
+        self.api_key = api_key or settings.GOOGLE_API_KEY
+        self.base_url = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
         self.headers = {
             "Authorization": f"Bearer {self.api_key}",
-            "Content-Type": "application/json"
+            "Content-Type": "application/json",
         }
 
     async def generate(self, request: ChatCompletionRequest) -> ProviderResult:
         async with httpx.AsyncClient() as client:
             payload = request.model_dump(exclude_unset=True, exclude={"provider"})
-            
-            # For MVP, disable streaming as it requires SSE handling
-            payload['stream'] = False
-            
+            payload["stream"] = False
+
             start = time.time()
             response = await client.post(
                 self.base_url,
                 headers=self.headers,
                 json=payload,
-                timeout=30.0
+                timeout=30.0,
             )
             response.raise_for_status()
             latency_ms = (time.time() - start) * 1000
             data = response.json()
-            
-            # Map Groq response to unified schema
+
             choices = []
             for item in data.get("choices", []):
                 msg_data = item.get("message", {})
-                message = ChatMessage(role=msg_data.get("role", "assistant"), content=msg_data.get("content", ""))
+                message = ChatMessage(
+                    role=msg_data.get("role", "assistant"),
+                    content=msg_data.get("content", ""),
+                )
                 choice = ChatChoice(
                     index=item.get("index", 0),
                     message=message,
-                    finish_reason=item.get("finish_reason")
+                    finish_reason=item.get("finish_reason"),
                 )
                 choices.append(choice)
-                
+
             usage_data = data.get("usage", {})
             usage = Usage(
                 prompt_tokens=usage_data.get("prompt_tokens", 0),
                 completion_tokens=usage_data.get("completion_tokens", 0),
-                total_tokens=usage_data.get("total_tokens", 0)
+                total_tokens=usage_data.get("total_tokens", 0),
             )
-            
+
             chat_response = ChatCompletionResponse(
                 id=data.get("id", f"chatcmpl-{int(time.time())}"),
                 created=data.get("created", int(time.time())),
                 model=data.get("model", request.model),
                 choices=choices,
-                usage=usage
+                usage=usage,
             )
 
-            # Extract rate-limit headers for key rotation tracking
             rl_headers = {
-                k: v for k, v in response.headers.items()
+                k: v
+                for k, v in response.headers.items()
                 if k.lower().startswith("x-ratelimit")
             }
 
             return ProviderResult(
                 response=chat_response,
-                provider="groq",
+                provider="google",
                 latency_ms=latency_ms,
                 rate_limit_headers=rl_headers,
             )
 
     async def health_check(self) -> bool:
-        # Simple health check, maybe hitting a very lightweight endpoint or just checking API key config
         if not self.api_key:
             return False
-        # For simplicity in MVP, assume healthy if API key exists
         return True
 
     async def get_cost_per_token(self) -> Dict[str, float]:
-        # Very rough estimates for Llama 3 on Groq
         return {
-            "input": 0.0000005,
-            "output": 0.0000015
+            "input": 0.0,
+            "output": 0.0,
         }

--- a/routing/router.py
+++ b/routing/router.py
@@ -11,9 +11,10 @@ import logging
 import httpx
 from typing import Set
 
-from core.schemas import ChatCompletionRequest, ChatCompletionResponse, ProviderResult
+from core.schemas import ChatCompletionRequest, ProviderResult
 from core.key_manager import key_manager
 from core.database import record_usage
+from core.config import settings
 from core.metrics import (
     PROVIDER_REQUESTS,
     PROVIDER_LATENCY,
@@ -21,14 +22,30 @@ from core.metrics import (
     TOKENS_PROCESSED,
 )
 from providers.groq_provider import GroqProvider
+from providers.google_provider import GoogleProvider
+from providers.anthropic_provider import AnthropicProvider
 
 logger = logging.getLogger("switchboard.router")
 
 
 class Router:
-    def __init__(self):
-        # For MVP, only Groq is supported
-        self.provider_name = "groq"
+    def __init__(self, provider_name: str | None = None):
+        resolved_provider = provider_name or settings.SWITCHBOARD_PROVIDER or "groq"
+        providers = {
+            "groq": GroqProvider,
+            "google": GoogleProvider,
+            "anthropic": AnthropicProvider,
+        }
+
+        if resolved_provider not in providers:
+            valid = ", ".join(sorted(providers.keys()))
+            raise ValueError(
+                f"Unknown provider '{resolved_provider}'. Valid providers: {valid}"
+            )
+
+        self.provider_name = resolved_provider
+        self.provider_cls = providers[resolved_provider]
+        self.provider_registry = providers
 
     async def route_request(self, request: ChatCompletionRequest) -> ProviderResult:
         """
@@ -37,24 +54,37 @@ class Router:
         """
         tried_key_ids: Set[int] = set()
         last_error = None
+        provider_name = request.provider or self.provider_name
+        if provider_name not in self.provider_registry:
+            valid = ", ".join(sorted(self.provider_registry.keys()))
+            raise ValueError(f"Unknown provider '{provider_name}'. Valid providers: {valid}")
 
-        # Try up to 10 keys (practical upper bound)
-        for attempt in range(10):
+        try:
+            all_keys = await key_manager.get_all_keys(provider_name)
+        except RuntimeError as e:
+            raise Exception(str(e)) from e
+
+        # Cycle through all enabled keys once per request
+        for attempt, (api_key, key_id) in enumerate(all_keys):
             try:
-                api_key, key_id = await key_manager.get_available_key(self.provider_name)
+                if attempt == 0:
+                    api_key, key_id = await key_manager.get_available_key(provider_name)
             except RuntimeError as e:
-                raise Exception(str(e)) from e
+                last_error = e
+                if attempt == 0:
+                    api_key, key_id = all_keys[0]
+                else:
+                    continue
 
             if key_id in tried_key_ids:
-                # We've cycled through all available keys
-                break
+                continue
             tried_key_ids.add(key_id)
 
             if attempt > 0:
                 KEY_SWITCHES.inc()
                 logger.info(f"Switched to key id={key_id} (attempt {attempt + 1})")
 
-            provider = GroqProvider(api_key=api_key)
+            provider = self.provider_registry[provider_name](api_key=api_key)
 
             try:
                 result = await provider.generate(request)
@@ -65,9 +95,9 @@ class Router:
 
                 # Record metrics
                 PROVIDER_REQUESTS.labels(
-                    provider=self.provider_name, key_label=str(key_id), status="success"
+                    provider=provider_name, key_label=str(key_id), status="success"
                 ).inc()
-                PROVIDER_LATENCY.labels(provider=self.provider_name).observe(
+                PROVIDER_LATENCY.labels(provider=provider_name).observe(
                     result.latency_ms / 1000
                 )
                 TOKENS_PROCESSED.labels(direction="input").inc(
@@ -97,26 +127,26 @@ class Router:
                     logger.warning(f"Key id={key_id} got 429 — marking exhausted and retrying")
                     await key_manager.mark_key_exhausted(key_id)
                     PROVIDER_REQUESTS.labels(
-                        provider=self.provider_name, key_label=str(key_id), status="rate_limited"
+                        provider=provider_name, key_label=str(key_id), status="rate_limited"
                     ).inc()
                     continue
                 elif status == 401:
                     logger.warning(f"Key id={key_id} got 401 — invalid key, disabling and trying next")
                     await key_manager.toggle_key(key_id, enabled=False)
                     PROVIDER_REQUESTS.labels(
-                        provider=self.provider_name, key_label=str(key_id), status="auth_error"
+                        provider=provider_name, key_label=str(key_id), status="auth_error"
                     ).inc()
                     continue
                 elif status >= 500:
                     logger.warning(f"Key id={key_id} got {status} — trying next key")
                     PROVIDER_REQUESTS.labels(
-                        provider=self.provider_name, key_label=str(key_id), status="server_error"
+                        provider=provider_name, key_label=str(key_id), status="server_error"
                     ).inc()
                     continue
                 else:
                     # 4xx other than 429/401 — don't retry
                     PROVIDER_REQUESTS.labels(
-                        provider=self.provider_name, key_label=str(key_id), status="client_error"
+                        provider=provider_name, key_label=str(key_id), status="client_error"
                     ).inc()
                     raise
 
@@ -124,11 +154,11 @@ class Router:
                 last_error = e
                 logger.error(f"Key id={key_id} unexpected error: {e}")
                 PROVIDER_REQUESTS.labels(
-                    provider=self.provider_name, key_label=str(key_id), status="error"
+                    provider=provider_name, key_label=str(key_id), status="error"
                 ).inc()
                 continue
 
         raise Exception(
-            f"All API keys exhausted for provider '{self.provider_name}'. "
+            f"All API keys exhausted for provider '{provider_name}'. "
             f"Tried {len(tried_key_ids)} key(s). Last error: {last_error}"
         )

--- a/tests/test_provider_routing.py
+++ b/tests/test_provider_routing.py
@@ -1,0 +1,102 @@
+"""
+Tests for provider selection via request.provider.
+"""
+
+import os
+import tempfile
+import time
+
+_tmpdir = tempfile.mkdtemp()
+os.environ["SQLITE_DB_PATH"] = os.path.join(_tmpdir, "test_provider_routing.db")
+
+from cryptography.fernet import Fernet
+
+os.environ["ENCRYPTION_KEY"] = Fernet.generate_key().decode()
+os.environ["GROQ_API_KEY"] = ""
+os.environ["GOOGLE_API_KEY"] = ""
+os.environ["ANTHROPIC_API_KEY"] = ""
+os.environ["REDIS_URL"] = "redis://localhost:6379/0"
+
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, patch
+
+from core.database import init_db
+from core.key_manager import key_manager
+from core.schemas import (
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatMessage,
+    ChatChoice,
+    Usage,
+    ProviderResult,
+)
+from routing.router import Router
+
+
+def _make_request(provider: str | None = None):
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[ChatMessage(role="user", content="Hello")],
+        provider=provider,
+    )
+
+
+def _make_provider_result(provider: str):
+    return ProviderResult(
+        response=ChatCompletionResponse(
+            id="test-1",
+            created=int(time.time()),
+            model="test-model",
+            choices=[
+                ChatChoice(
+                    index=0,
+                    message=ChatMessage(role="assistant", content="Hi!"),
+                    finish_reason="stop",
+                )
+            ],
+            usage=Usage(prompt_tokens=5, completion_tokens=3, total_tokens=8),
+        ),
+        provider=provider,
+        latency_ms=150.0,
+        rate_limit_headers={},
+    )
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def setup_db():
+    await init_db()
+    from core.database import get_db
+
+    db = await get_db()
+    await db.execute("DELETE FROM api_keys")
+    await db.commit()
+    yield
+
+
+@pytest.mark.asyncio
+async def test_router_routes_to_requested_provider():
+    with patch("routing.router.GoogleProvider") as MockProvider, patch(
+        "routing.router.key_manager.get_available_key",
+        new=AsyncMock(return_value=("test_google_key", 1)),
+    ), patch(
+        "routing.router.key_manager.get_all_keys",
+        new=AsyncMock(return_value=[("test_google_key", 1)]),
+    ):
+        router = Router()
+        mock_result = _make_provider_result("google")
+        instance = MockProvider.return_value
+        instance.generate = AsyncMock(return_value=mock_result)
+
+        result = await router.route_request(_make_request(provider="google"))
+
+        MockProvider.assert_called_once_with(api_key="test_google_key")
+        assert result.provider == "google"
+        instance.generate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_router_rejects_unknown_provider():
+    router = Router()
+    with pytest.raises(ValueError, match="Unknown provider"):
+        await router.route_request(_make_request(provider="unknown"))

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -14,6 +14,7 @@ from cryptography.fernet import Fernet
 os.environ["ENCRYPTION_KEY"] = Fernet.generate_key().decode()
 os.environ["GROQ_API_KEY"] = ""
 os.environ["GOOGLE_API_KEY"] = ""
+os.environ["ANTHROPIC_API_KEY"] = ""
 os.environ["REDIS_URL"] = "redis://localhost:6379/0"
 
 import pytest
@@ -75,7 +76,6 @@ async def setup():
     db = await get_db()
     await db.execute("DELETE FROM api_keys")
     await db.commit()
-    await db.close()
     yield
 
 
@@ -84,10 +84,10 @@ async def test_router_picks_key_and_calls_provider():
     """Router should get a key from KeyManager and call the provider."""
     await key_manager.add_key("groq", "gsk_test_key_1", "test1")
 
-    router = Router()
     mock_result = _make_provider_result()
 
     with patch("routing.router.GroqProvider") as MockProvider:
+        router = Router()
         instance = MockProvider.return_value
         instance.generate = AsyncMock(return_value=mock_result)
 
@@ -103,7 +103,6 @@ async def test_router_switches_key_on_429():
     await key_manager.add_key("groq", "gsk_key_a", "a")
     await key_manager.add_key("groq", "gsk_key_b", "b")
 
-    router = Router()
     mock_result = _make_provider_result()
 
     # First call raises 429, second succeeds
@@ -124,6 +123,7 @@ async def test_router_switches_key_on_429():
         return mock_result
 
     with patch("routing.router.GroqProvider") as MockProvider:
+        router = Router()
         instance = MockProvider.return_value
         instance.generate = AsyncMock(side_effect=side_effect)
 
@@ -137,8 +137,6 @@ async def test_router_raises_when_all_keys_exhausted():
     """Router should raise when every key returns 429."""
     await key_manager.add_key("groq", "gsk_only_key", "only")
 
-    router = Router()
-
     mock_response_429 = MagicMock()
     mock_response_429.status_code = 429
     mock_response_429.request = MagicMock()
@@ -147,6 +145,7 @@ async def test_router_raises_when_all_keys_exhausted():
     )
 
     with patch("routing.router.GroqProvider") as MockProvider:
+        router = Router()
         instance = MockProvider.return_value
         instance.generate = AsyncMock(side_effect=error_429)
 


### PR DESCRIPTION
## Overview
This PR enables true multi-provider routing by letting clients specify a provider per request, adding provider implementations for Google and Anthropic, and updating the router to select keys by provider. It also updates configuration, docs, and tests to reflect the new routing behavior.
## Changes
- **Per-request provider selection**
  - Adds `provider: Optional[str]` to `ChatCompletionRequest`, allowing clients to target a vendor in the request body.
  - Router now resolves provider from `request.provider`, falling back to the configured default.
- **Provider implementations**
  - Adds `GoogleProvider` and `AnthropicProvider` implementing the `LLMProvider` interface.
  - Provider payloads map responses into the unified `ChatCompletionResponse`.
- **Routing updates**
  - Router now uses a provider registry and validates provider names.
  - Key selection and fallback are scoped by provider.
  - Adds `KeyManager.get_all_keys(provider)` to iterate across enabled keys for that provider.
- **Configuration & docs**
  - Adds `SWITCHBOARD_PROVIDER` default provider setting.
  - Documents new provider env vars and usage examples.
- **Tests**
  - Adds provider-routing coverage to ensure per-request provider selection is respected.
## Why
The router was previously hardcoded to Groq, and clients couldn’t request a specific provider. This blocked multi-provider deployments even when other provider keys existed. These changes unblock multi-provider routing and make the system extensible.
## Notes / Follow-ups
- Streaming remains disabled (as before).
- Additional provider-specific limits/costing can be layered in later.