### PR TITLE
chore(deps-dev): bump pytest and pytest-asyncio together (supersedes #12, #15)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,5 +8,5 @@
 
 -r requirements.txt
 
-pytest==8.1.1
-pytest-asyncio==0.23.8
+pytest==9.1.1
+pytest-asyncio==1.4.0


### PR DESCRIPTION
Supersedes #12 and #15.

## Why one PR instead of two

Dependabot opened these separately and **neither can merge alone**. Each bumps one half of a pair that has to move together:

```
#12  pytest 8.1.1 -> 9.1.1     blocked by: pytest-asyncio 0.23.8 depends on pytest<9
#15  pytest-asyncio -> 1.4.0   blocked by: pytest-asyncio 1.4.0 depends on pytest>=8.4
```

Both failed at `pip install` with `ResolutionImpossible`, before a single test ran. There is no merge order that works — the two versions have to land in the same commit.

## Verification

Clean venv, both bumps applied:

```
platform darwin -- Python 3.12.1, pytest-9.1.1, pluggy-1.6.0
plugins: asyncio-1.4.0, anyio-4.14.2
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None,
         asyncio_default_test_loop_scope=function

109 passed, 1 deselected, 1 warning in 0.25s
```

The single remaining warning is the pre-existing `PydanticDeprecatedSince20` from `core/config.py:4`. It is unrelated to this change and is present on `main` today.

Also confirmed the CI step that guards the opt-in tier still holds:

```
$ pytest -m integration --collect-only -q
1/110 tests collected (109 deselected)
```

## No other changes were needed

pytest-asyncio 1.x is a major version, so this is the part worth scrutiny:

- `asyncio_mode = strict` in `pytest.ini` works unchanged.
- 1.x defaults `asyncio_default_fixture_loop_scope` to `None` and the test loop scope to `function`, which is what the suite already assumed. Nothing had to be re-scoped.
- No new deprecation warnings appeared.
- No test file or fixture required edits.

Both packages require Python `>=3.10`; the CI matrix runs 3.11 and 3.12.

## Scope

`requirements-dev.txt` only. Dev dependencies do not ship — the Dockerfile installs `requirements.txt` alone, so the production image is unaffected.
