### PR TITLE
chore(deps): bump fastapi stack with the instrumentator major (supersedes #11)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,11 @@ pydantic-settings==2.15.0
 # Without GOOGLE_API_KEY the cache disables itself and requests are still
 # served, but the package is imported at module load so it is not optional here.
 google-genai==1.64.0
-numpy==2.5.2
+# CEILING: numpy 2.5.0 raised its floor to Python >=3.12. The CI matrix tests
+# 3.11 and the Dockerfile ships 3.11-slim, so 2.4.x is the last usable line.
+# Dependabot will keep proposing 2.5.x; it cannot install here. Lift this only
+# together with the Python floor in ci.yml and the Dockerfile.
+numpy==2.4.6
 
 # --- Storage / crypto --------------------------------------------------------
 aiosqlite==0.22.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,8 +7,8 @@
 # .github/dependabot.yml) proposes the upgrades.
 
 # --- Web framework -----------------------------------------------------------
-fastapi==0.110.0
-uvicorn==0.29.0
+fastapi==0.141.1
+uvicorn==0.52.4
 
 # --- HTTP client -------------------------------------------------------------
 # Every provider adapter talks to its upstream over httpx directly. There is no
@@ -28,7 +28,7 @@ pydantic-settings==2.15.0
 # Without GOOGLE_API_KEY the cache disables itself and requests are still
 # served, but the package is imported at module load so it is not optional here.
 google-genai==1.64.0
-numpy==2.4.2
+numpy==2.5.2
 
 # --- Storage / crypto --------------------------------------------------------
 aiosqlite==0.22.1
@@ -36,4 +36,4 @@ cryptography==50.0.0
 
 # --- Observability -----------------------------------------------------------
 prometheus-client==0.26.0
-prometheus-fastapi-instrumentator==7.1.0
+prometheus-fastapi-instrumentator==8.1.0


### PR DESCRIPTION
Supersedes #11.

## What #11 got wrong

Dependabot's group bump moved FastAPI 0.110.0 → 0.141.1 and broke the gateway completely. 31 tests failed, all with the same error:

```
AttributeError: '_IncludedRouter' object has no attribute 'path'
  prometheus_fastapi_instrumentator/routing.py:55
```

FastAPI changed its internal router structure, and `prometheus-fastapi-instrumentator==7.1.0` reaches into it. Because the instrumentator installs middleware, it raised on **every** request regardless of route — which is why auth tests, admin tests and routing tests all went red at once, even though none of them are about metrics.

## Why Dependabot couldn't fix it itself

The fix is instrumentator **8.1.0**, and #11 doesn't include it. That isn't Dependabot being wrong — it's our config:

- 7.1.0 → 8.1.0 is a **major** bump, so it's excluded from the `minor-and-patch` group and should arrive as its own PR.
- `.github/dependabot.yml` sets `open-pull-requests-limit: 5`, and the pip queue was already full with #11–#15.

So the group shipped the FastAPI bump while the companion fix that makes it work never got a slot. Same failure shape as #12/#15 — two halves of one change, delivered separately.

## What this PR does

```
fastapi                           0.110.0 -> 0.141.1
uvicorn                           0.29.0  -> 0.52.4
numpy                             2.4.2   -> 2.4.6    <- NOT 2.5.2, see below
prometheus-fastapi-instrumentator 7.1.0   -> 8.1.0    <- not in #11
```

### The second defect in #11: numpy

#11 proposed `numpy==2.5.2`. That version **cannot install on Python 3.11**:

```
2.4.6  requires-python >=3.11
2.5.0  requires-python >=3.12
```

The CI matrix tests 3.11 and the Dockerfile ships `python:3.11-slim`, so it failed both the `tests (py3.11)` leg and the `docker image builds` job:

```
ERROR: No matching distribution found for numpy==2.5.2
```

This is independent of the instrumentator breakage, and it is the worse of the two — it would have broken the **shipped image**, not just the test run.

Worth being straight about how this was found: my first push had `2.5.2` in it, because the venv I verified in locally is 3.12, where it installs fine. The py3.11 leg and the Docker job were the only things that could have caught it, and they did. That is the matrix earning its keep.

Pinned to `2.4.6` — the newest release in the line that still supports 3.11 — rather than reverting to `2.4.2`, so the supported patch updates are still taken. The ceiling is documented at the pin.

This also pulls `starlette` 0.x → **1.6.0** transitively, which is worth knowing about even though nothing here depends on starlette directly.

## Verification

Clean venv, all four bumps:

```
109 passed, 1 deselected, 1 warning in 0.18s
```

The one warning is the pre-existing `PydanticDeprecatedSince20` from `core/config.py:4`, already present on `main`.

The suite already covers the exact surface that broke. `tests/test_auth.py:254` asserts `/metrics` returns 200 with an admin token **and** that the body contains `http_requests_total` — that second assertion is what proves the auth guard wraps the real exporter instead of an empty stub, so a silently-broken instrumentator can't pass.

### Live server smoke test

The original failure was in middleware and `uvicorn` moved as well, so the ASGI test transport alone didn't feel like enough. Booted a real uvicorn server against the bumped stack:

| Route | Result |
|---|---|
| `/health` | 200 · `{"status":"ok","version":"0.2.0","cache":"unavailable"}` |
| `/metrics` unauthenticated | 401 |
| `/metrics` with admin token | 200 · real exporter output (`switchboard_cache_hits_total`, …) |
| `/openapi.json` with admin token | 200 · full schema |
| `/docs` | 200 |
| `/admin/keys` with admin token | 200 · `{"keys":[]}` |

`cache: unavailable` is correct — there was no Redis on the smoke host, and the gateway logged the failure and kept serving, which is the documented degradation path.

## Scope

`requirements.txt` only. No source changes were needed.

## Follow-ups, deliberately not in this PR

Two config changes would stop this class of problem recurring. Both are judgement calls rather than fixes, so they are left out:

1. **`open-pull-requests-limit: 5`** is what caused a major bump and its companion to be split across the queue boundary. Raising it, or splitting the pip ecosystem config, would prevent that.

2. **Dependabot will keep proposing numpy 2.5.x every week**, and it will keep failing, until the project's Python floor moves off 3.11. An `ignore` rule for `numpy` above `2.4.x` would silence it — but that trades a recurring red PR for a silently-pinned dependency, and it should be decided together with when 3.11 gets dropped. Related: #9, which proposed jumping the base image to 3.14 and was closed for the same reason.
