### PR TITLE
fix: do not emit sentinel similarity on cache misses

### DIFF
--- a/gateway/main.py
+++ b/gateway/main.py
@@ -280,7 +280,7 @@ async def chat_completions(request: ChatCompletionRequest, response: Response):
         response.headers["X-Cache"] = "MISS"
         response.headers["X-Provider"] = provider_result.provider
         response.headers["X-Latency-Ms"] = f"{provider_result.latency_ms:.1f}"
-        if highest_similarity >= -1.0:
+        if highest_similarity > -1.0:
             response.headers["X-Semantic-Similarity"] = f"{highest_similarity:.4f}"
         return provider_result.response
     except Exception as e:

--- a/tests/test_semantic_cache.py
+++ b/tests/test_semantic_cache.py
@@ -39,8 +39,10 @@ from core.schemas import (
     ChatCompletionRequest,
     ChatCompletionResponse,
     ChatMessage,
+    ProviderResult,
     Usage,
 )
+from gateway import main as gateway_main
 
 
 def _request(content: str) -> ChatCompletionRequest:
@@ -63,6 +65,15 @@ def _response(content: str = "42") -> ChatCompletionResponse:
             )
         ],
         usage=Usage(),
+    )
+
+
+def _provider_result() -> ProviderResult:
+    return ProviderResult(
+        response=_response(),
+        provider="groq",
+        latency_ms=12.0,
+        rate_limit_headers={},
     )
 
 
@@ -157,6 +168,60 @@ async def test_semantic_cache_empty_prompt_short_circuits():
     assert cached is None
     assert similarity == -1.0
     cache.redis_client.keys.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gateway_miss_omits_similarity_when_no_comparison_ran(
+    client_scope_client, monkeypatch
+):
+    """A disabled cache must not expose its no-comparison sentinel as a score."""
+    monkeypatch.setattr(
+        gateway_main.cache,
+        "get_cached_response",
+        AsyncMock(return_value=(None, -1.0)),
+    )
+    monkeypatch.setattr(gateway_main.cache, "set_cached_response", AsyncMock())
+    monkeypatch.setattr(
+        gateway_main.router,
+        "route_request",
+        AsyncMock(return_value=_provider_result()),
+    )
+
+    response = await client_scope_client.post(
+        "/v1/chat/completions",
+        json=_request("cache disabled").model_dump(mode="json"),
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-Cache"] == "MISS"
+    assert "X-Semantic-Similarity" not in response.headers
+
+
+@pytest.mark.asyncio
+async def test_gateway_miss_reports_similarity_when_comparison_ran(
+    client_scope_client, monkeypatch
+):
+    """A real below-threshold comparison remains visible on a cache miss."""
+    monkeypatch.setattr(
+        gateway_main.cache,
+        "get_cached_response",
+        AsyncMock(return_value=(None, 0.5)),
+    )
+    monkeypatch.setattr(gateway_main.cache, "set_cached_response", AsyncMock())
+    monkeypatch.setattr(
+        gateway_main.router,
+        "route_request",
+        AsyncMock(return_value=_provider_result()),
+    )
+
+    response = await client_scope_client.post(
+        "/v1/chat/completions",
+        json=_request("below threshold").model_dump(mode="json"),
+    )
+
+    assert response.status_code == 200
+    assert response.headers["X-Cache"] == "MISS"
+    assert response.headers["X-Semantic-Similarity"] == "0.5000"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## What this changes

Fixes #18 by emitting `X-Semantic-Similarity` on a cache miss only when the cache actually computed a comparison. The no-comparison sentinel is no longer serialized as `-1.0000`.

## Why

The gateway initializes the miss-path similarity to `-1.0`, which represents an unavailable comparison. The old `>= -1.0` guard therefore added a misleading similarity header to every miss, including requests with semantic caching disabled. A strict `> -1.0` check preserves real comparison scores while omitting the sentinel.

## How it was verified

- [x] `python -m pytest -q` — 111 passed, 1 deselected.
- [x] `python -m pytest tests/test_semantic_cache.py -k gateway_miss -q` — 2 passed.
- [x] `python -m pytest -m integration --collect-only -q` — integration test collected successfully.
- [x] `python -m compileall -q gateway cache core providers routing tests` — passed.
- [x] `mypy --follow-imports=skip --ignore-missing-imports --explicit-package-bases gateway/main.py tests/test_semantic_cache.py` — passed.
- [x] `docker build -t switchboard-ci:issue-18 .` — passed; the production image contains neither pytest nor `.env`.
- [x] Added endpoint-level regression coverage for both the unavailable-comparison sentinel and a real below-threshold score.

## Compatibility

Cache hits and cache misses with a computed similarity remain unchanged. Only the misleading `-1.0000` header is removed when no comparison ran.

## Checklist

- [x] I agree my contribution is licensed under the [MIT License](../LICENSE)
- [x] No secrets, API keys, or `.env` contents are included in the diff
- [x] No nearby ASCII diagram was changed
- [x] No documentation site files were changed
- [x] No new tests need live credentials

## Anything you are unsure about

Live integration tests were not run because they require a real Google API key and a reachable Redis instance. The repository does not configure a formatter or linter; Black would reformat pre-existing code outside this change. A full mypy traversal reports existing type errors in unrelated provider, routing, and cache modules; the changed files pass the focused check above.

## Remote status

The repository's Vercel check reports `Authorization required to deploy`, and the GitHub Actions `CI` workflow is waiting for maintainer approval for this fork pull request. This change touches only gateway code and tests, not the site or deployment configuration.

## AI assistance disclosure

This contribution was prepared with AI assistance. The implementation, regression tests, and verification results were reviewed before submission.
