### PR TITLE
Fix: Use dynamic VERSION variable in FastAPI app

### DIFF
--- a/gateway/main.py
+++ b/gateway/main.py
@@ -118,7 +118,7 @@ async def _usage_bucket_cleanup():
 app = FastAPI(
     title="SwitchBoard Gateway",
     description="Multi-provider LLM gateway with key rotation & semantic caching",
-    version="0.2.0",
+    version=VERSION,
     lifespan=lifespan,
     # The auto-mounted docs handed the complete API schema to anyone who asked,
     # including the exact request body for adding a provider key. Disabled here


### PR DESCRIPTION
Closes #16. Replaced the hardcoded version string with the existing VERSION variable in gateway/main.py to ensure the FastAPI app stays synchronized with future releases.