### PR TITLE
test: cover stream rejection, and unwind the CHANGELOG history rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `providers/groq_provider.py` and `providers/google_provider.py` have been removed
   since the gateway now catches this before reaching the providers.
 
-### Added
-
 ## [0.2.0] — 2026-08-22
 
 First release with a license. SwitchBoard's repository was already public but carried no
@@ -94,8 +92,8 @@ The version number is 0.2.0 rather than 0.1.0 because `/health` has been reporti
 
 ### Security
 
-- **`stream: true` now returns HTTP 400** with an OpenAI-compatible error payload
-  instead of being silently downgraded to a non-streamed response.
+- Documented that `"stream": true` is silently downgraded to a non-streamed response
+  rather than rejected, so nobody builds on an assumption that does not hold.
 
 ## [0.1.0]
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -97,7 +97,7 @@ tool or function calls, error-payload shape, the full `usage` object, or what ha
 when a client sends a parameter the gateway does not model. One concrete gap was
 already known: `core/schemas.py:12` accepted `stream`, but the provider adapters forced
 it to `False`, so a client requesting a stream got a complete response and no error —
-a silent contract violation. (Fixed in v0.2.1+: `stream: true` now returns HTTP 400.)
+a silent contract violation. (Fixed on `main`, unreleased: `stream: true` now returns HTTP 400.)
 
 **Context:** The README's Limitations section now scopes the claim honestly, so this is
 not urgent, but the gap between "works with the OpenAI SDK" and "implements the OpenAI

--- a/gateway/main.py
+++ b/gateway/main.py
@@ -245,6 +245,16 @@ cache = RedisCache()
 @app.post("/v1/chat/completions", response_model=ChatCompletionResponse,
           dependencies=[Depends(require_client)])
 async def chat_completions(request: ChatCompletionRequest, response: Response):
+    # Streaming is modelled in the schema but not implemented, and this used to
+    # be a silent downgrade: the adapters forced stream back to False and the
+    # caller got one complete object with a 200. An error is strictly better,
+    # because the caller learns the truth.
+    #
+    # Rejected here rather than as a validator on ChatCompletionRequest: a
+    # pydantic validator raises before the handler and FastAPI renders it as a
+    # 422 with pydantic's own error list, but OpenAI clients read
+    # error.message / error.type / error.param. Matching that shape is worth
+    # more to a caller than reusing the validation machinery.
     if request.stream:
         return JSONResponse(
             status_code=400,

--- a/tests/test_stream_rejection.py
+++ b/tests/test_stream_rejection.py
@@ -1,0 +1,67 @@
+"""`stream: true` must fail loudly.
+
+The gateway accepts a `stream` field it does not implement. It used to force it
+back to False in the adapters and return a complete response with a 200, which
+left the caller no way to know its request had been overridden. These tests pin
+the replacement contract: a 400 in the OpenAI error shape, and no provider call.
+
+The shape assertion is the point of the test, not decoration. An OpenAI client
+reads `error.message`; if a later refactor moves this behind a pydantic
+validator the status becomes 422 and the body becomes pydantic's error list,
+and every one of those clients breaks silently. That is the regression this
+file exists to catch.
+"""
+
+import pytest
+
+from tests.test_auth import CHAT_BODY
+
+
+@pytest.mark.asyncio
+async def test_stream_true_is_rejected(client_scope_client):
+    resp = await client_scope_client.post(
+        "/v1/chat/completions", json={**CHAT_BODY, "stream": True}
+    )
+    assert resp.status_code == 400
+
+    error = resp.json()["error"]
+    assert error["type"] == "unsupported_parameter"
+    assert error["param"] == "stream"
+    assert "not supported" in error["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_stream_true_never_reaches_the_router(client_scope_client, stub_router):
+    """Rejecting after the provider call would still spend quota."""
+    await client_scope_client.post(
+        "/v1/chat/completions", json={**CHAT_BODY, "stream": True}
+    )
+    stub_router.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stream_true_still_401s_when_unauthenticated(raw_client, stub_router):
+    """Auth outranks validation: an anonymous caller must not be able to probe
+    which parameters the gateway supports."""
+    resp = await raw_client.post(
+        "/v1/chat/completions", json={**CHAT_BODY, "stream": True}
+    )
+    assert resp.status_code == 401
+    stub_router.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stream_false_is_accepted(client_scope_client, stub_router):
+    resp = await client_scope_client.post(
+        "/v1/chat/completions", json={**CHAT_BODY, "stream": False}
+    )
+    assert resp.status_code != 400
+    assert stub_router.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_absent_stream_is_accepted(client_scope_client, stub_router):
+    """The default is False, so omitting the field must not trip the check."""
+    resp = await client_scope_client.post("/v1/chat/completions", json=CHAT_BODY)
+    assert resp.status_code != 400
+    assert stub_router.await_count == 1


### PR DESCRIPTION
## What this changes

Adds the tests #31 skipped, restores the released `[0.2.0]` CHANGELOG entry that #31 rewrote, and writes down why the stream check lives in the handler rather than in a pydantic validator. No behaviour change.

## Why

Follow-ups to #31, which landed the fix for #22 correctly but left three things.

**Tests.** #22 asked for them and CONTRIBUTING lists "new code with no tests" as the first thing that gets a PR sent back. #31 shipped none, so nothing failed if the guard came out. `tests/test_stream_rejection.py` pins the whole contract: the 400, the OpenAI error shape, that the router is never awaited, that auth outranks the check, and that `stream: false` and an absent `stream` both still pass through.

The shape assertion is the point, not decoration. An OpenAI client reads `error.message`. If a later refactor moves this behind a pydantic validator the status becomes 422 and the body becomes pydantic's error list, and every one of those clients breaks silently. That is the regression this file exists to catch.

**CHANGELOG.** #31 rewrote the `### Security` bullet under the released `[0.2.0]` to describe the new behaviour. 0.2.0 shipped the silent downgrade and documented it honestly; that entry records what that release did, not what `main` does now. Restored, and the empty `### Added` heading under `[Unreleased]` is gone. TODOS.md no longer cites a v0.2.1 that does not exist.

**Comment.** Handler check rather than a validator on `ChatCompletionRequest` was the open design question on #22. A validator raises before the handler and FastAPI renders it as a 422 with pydantic's error list, but OpenAI clients read `error.message` / `error.type` / `error.param`. Worth writing down rather than re-litigating in six months.

## How it was verified

- [x] `pytest` is green locally
- [x] Added or updated tests covering the change
- [x] Ran the affected path by hand (below)

`114 passed, 1 deselected` on Python 3.12, up from 109.

Mutation-checked the new tests rather than trusting a green run: replacing `if request.stream:` with `if False:` fails 2 of the 5, so they hold the guard down instead of passing regardless.

By hand against the merged code: `stream: true` returns 400 with `{"error": {"message": ..., "type": "unsupported_parameter", "param": "stream"}}` and never reaches the router, `stream: false` and an omitted `stream` both route normally, and an unauthenticated `stream: true` still gets 401 rather than the 400.

Touches auth-adjacent ordering, so specifically: `require_client` still runs before the handler body, which is what keeps an anonymous caller from probing which parameters the gateway supports. `test_stream_true_still_401s_when_unauthenticated` pins that.

## Checklist

- [x] I agree my contribution is licensed under the [MIT License](../LICENSE)
- [x] No secrets, API keys, or `.env` contents in the diff
- [x] Any nearby ASCII diagram is still accurate, or was updated
- [x] If I edited `site/docs.html`, I made the matching change in `README.md` (neither is touched here)
- [x] New tests needing live credentials are marked `@pytest.mark.integration` (none need credentials)

## Anything you are unsure about

Two of the five tests go beyond what #22 asked for: `test_stream_true_never_reaches_the_router` and `test_stream_true_still_401s_when_unauthenticated`. I think both earn their place, since `tests/test_auth.py` already pins the same never-reaches-the-router property for auth and the reasoning is identical here, but say so if you would rather keep the file to the three cases the issue named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)