### PR TITLE
test: assert app.version tracks the VERSION file

### DIFF
--- a/tests/test_admin_api.py
+++ b/tests/test_admin_api.py
@@ -7,7 +7,11 @@ carries a valid ADMIN_TOKENS credential; the unauthenticated counterparts
 live in tests/test_auth.py against the `raw_client` fixture.
 """
 
+from pathlib import Path
+
 import pytest
+
+from gateway.main import app
 
 
 @pytest.mark.asyncio
@@ -115,3 +119,15 @@ async def test_health(raw_client):
     resp = await raw_client.get("/health")
     assert resp.status_code == 200
     assert resp.json()["status"] == "ok"
+
+
+def test_app_version_matches_the_version_file():
+    """`app.version` is what /openapi.json reports, and it was a string literal.
+
+    /health reads VERSION directly so it cannot drift, but the FastAPI
+    constructor is not covered by the `docs consistency` CI job, which only
+    checks README.md, the site, and CHANGELOG.md. Without this assert, the next
+    release bump can silently leave the schema reporting the old number.
+    """
+    expected = (Path(__file__).resolve().parent.parent / "VERSION").read_text().strip()
+    assert app.version == expected


### PR DESCRIPTION
## What this changes

Adds the regression test that #16 asked for and that #29 landed without. One test, 16 lines, in `tests/test_admin_api.py` beside the existing `test_health`.

## Why

#29 fixed the drift by replacing the hardcoded `version="0.2.0"` with the `VERSION` constant, but nothing guards that line against coming back:

- `/health` reads `VERSION` directly, so it cannot drift and does not cover the FastAPI constructor.
- The `docs consistency` CI job only checks `README.md`, `site/index.html`, `site/docs.html` and `CHANGELOG.md`. `gateway/main.py` is not in that list.

`app.version` is what `get_openapi` reports, so an unguarded literal means `/health` and `/openapi.json` can disagree after a release bump.

Relates to #16 (already closed by #29). No `Closes` keyword, since this is the follow-up test rather than the fix.

## How it was verified

- [x] `pytest` is green locally: `117 passed, 1 deselected`
- [x] Added or updated tests covering the change
- [ ] Ran the affected path by hand

**The verification recipe in #16 does not work, and is worth correcting.** It says to bump `VERSION` to `9.9.9` and confirm the test fails. Post-#29 that passes, because `app.version` and the test both read the same file and move together. That recipe only failed against the pre-fix hardcoded literal.

What the test actually catches is a re-introduced literal, checked both ways:

| State | Result |
|---|---|
| `version="0.2.0"` literal, `VERSION` unbumped | passes, correctly. Nothing is wrong yet. |
| `version="0.2.0"` literal, `VERSION` bumped to `9.9.9` | fails: `AssertionError: assert '0.2.0' == '9.9.9'` |

That second row is the real failure mode. Someone bumps the release and forgets `gateway/main.py`. The test turns silent drift into a red build at exactly release time. The commit message records this so nobody later deletes the test after the `9.9.9` trick does not fail for them.

Test placement: `test_health` already lives in `test_admin_api.py` despite not being an admin route, so this is the established home for the version surface. A separate file for one assert was not worth it.

## Checklist

- [x] I agree my contribution is licensed under the [MIT License](../LICENSE)
- [x] No secrets, API keys, or `.env` contents in the diff
- [x] Any nearby ASCII diagram is still accurate, or was updated
- [x] If I edited `site/docs.html`, I made the matching change in `README.md` (n/a, tests only)
- [x] New tests needing live credentials are marked `@pytest.mark.integration` (n/a, needs none)

## Anything you are unsure about

The test re-reads the `VERSION` file rather than importing the `VERSION` constant from `gateway.main`. Importing the constant would be shorter and still catch a re-introduced literal, but reading the file independently also catches the version-reading logic itself breaking. I followed the issue's approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)