### PR TITLE
Add provider and key_label metrics to TOKENS_PROCESSED

### DIFF
--- a/core/metrics.py
+++ b/core/metrics.py
@@ -37,7 +37,7 @@ KEY_SWITCHES = Counter(
 TOKENS_PROCESSED = Counter(
     "switchboard_tokens_processed_total",
     "Total tokens processed",
-    ["direction"],  # "input" or "output"
+    ["provider", "key_label", "direction"],
 )
 
 # --- Active keys gauge ---

--- a/routing/router.py
+++ b/routing/router.py
@@ -100,12 +100,12 @@ class Router:
                 PROVIDER_LATENCY.labels(provider=provider_name).observe(
                     result.latency_ms / 1000
                 )
-                TOKENS_PROCESSED.labels(direction="input").inc(
-                    result.response.usage.prompt_tokens
-                )
-                TOKENS_PROCESSED.labels(direction="output").inc(
-                    result.response.usage.completion_tokens
-                )
+                TOKENS_PROCESSED.labels(
+                    provider=provider_name, key_label=str(key_id), direction="input"
+                ).inc(result.response.usage.prompt_tokens)
+                TOKENS_PROCESSED.labels(
+                    provider=provider_name, key_label=str(key_id), direction="output"
+                ).inc(result.response.usage.completion_tokens)
 
                 # Record per-key usage for dashboard stats
                 total_tokens = (


### PR DESCRIPTION
## What this changes

Adds the `provider` and `key_label` tags to the `TOKENS_PROCESSED` Counter metric, and updates the router to supply them when incrementing the metric.

## Why

Fixes #42
Allows operators to monitor token spend per specific API key in Grafana. Currently, Prometheus can only query the number of requests per key via `PROVIDER_REQUESTS`, but billing is based on tokens. 

Note: Cardinality takes `TOKENS_PROCESSED` to 2 × providers × keys, which matches `PROVIDER_REQUESTS` and introduces no new risk.

## How it was verified

Checked that the `tests/test_routing.py` suite passes successfully, confirming that the new labels are being passed correctly to the metrics engine without raising any errors.

- [x] `pytest` is green locally
- [ ] Added or updated tests covering the change
- [ ] Ran the affected path by hand (say which, below)

## Checklist

- [x] I agree my contribution is licensed under the [MIT License](../LICENSE)
- [x] No secrets, API keys, or `.env` contents in the diff
- [x] Any nearby ASCII diagram is still accurate, or was updated
- [ ] If I edited `site/docs.html`, I made the matching change in `README.md`
- [ ] New tests needing live credentials are marked `@pytest.mark.integration`
